### PR TITLE
Move from ECP to LECO name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# experiment_control_protocol
+# LECO - Laboratory Experiment Control Protocol
 Design notes for a generic communication protocol to control experiments and measurement hardware.
 
 This initiative was born out of a desire of PyMeasure developers, contributors and users to achieve improved and more flexible experiment orchestration/execution, and to achieve (better) interoperation with other instrument control libraries.
 
-ECP is meant to be a specification for a (programming-language-independent) protocol to enable users to run experiments with a number of hardware devices, including logging, data storage, plotting, and GUI.
+LECO is meant to be a specification for a (programming-language-independent) protocol to enable users to run experiments with a number of hardware devices, including logging, data storage, plotting, and GUI.
 Communication will happen via messages (probably using [zeromq](https://zeromq.org/)) between participants in a single application or distributed over the network.
 
 [PyMeasure](https://pymeasure.readthedocs.io) is an obvious candidate for working with this protocol, and as such will influence the design somewhat, but we will take pains to make sure the protocol will be agnostic to the actual interface package (or language) used.

--- a/components.md
+++ b/components.md
@@ -1,6 +1,6 @@
 # Components
 
-This page provides details on the main component/entity types that make up a deployment of the ECP.
+This page provides details on the main component/entity types that make up a deployment of the LECO.
 
 ## Director
 A Director manages a part of or the entire setup, orchestrating the Components according to the needs of the experiment.
@@ -12,11 +12,11 @@ It can, among other things,
 Potentially a GUI could be attached here too.
 
 ## Actor
-An Actor is a component that interfaces with a (hardware) Device and that has a specific API on the ECP side.
+An Actor is a component that interfaces with a (hardware) Device and that has a specific API on the LECO side.
 An Actor must contain a separate Driver object which communicates with the Device.
 
-We define how the other ECP components interact with the Actor, how it determines and announces its capabilities, etc.
-An Actor implements the mapping between ECP messages and Driver calls/attribute access.
+We define how the other LECO components interact with the Actor, how it determines and announces its capabilities, etc.
+An Actor implements the mapping between LECO messages and Driver calls/attribute access.
 
 An Actor must contain/manage/provide
 * An Driver that communicates with the connected Device, including managing its lifecycle (init, operations, shutdown)
@@ -33,12 +33,12 @@ An Actor may contain/manage
 
 ### Driver
 The Driver object takes care of communicating with the Device, and is always contained in an Actor.
-This object is external to ECP, for example a `pymeasure.Instrument` instance or something from another instrument library.
-This is the place where all instrument libraries (including pymeasure) wire their hardware interface classes into ECP.
+This object is external to LECO, for example a `pymeasure.Instrument` instance or something from another instrument library.
+This is the place where all instrument libraries (including pymeasure) wire their hardware interface classes into LECO.
 
 Interfacing with the Driver is the task of instrument-library-specific Actors.
 
-Concerning the ECP, we draw the abstraction boundary at the Driver -- the details on how this communicates with a Device (SCPI, dll, ...) should not be relevant for the protocol details.
+Concerning the LECO, we draw the abstraction boundary at the Driver -- the details on how this communicates with a Device (SCPI, dll, ...) should not be relevant for the protocol details.
 
 :::{admonition} TODO
 We might want to add the notion of "Channels", especially for the multi-Director stuff
@@ -109,7 +109,7 @@ It only consumes message streams, but does not command `Actors`.
 
 ## Notes 
 ### Complexity scaling
-We want to leave the entry threshold as low as possible, the learning curve flat, and the usability of ECP modular.
+We want to leave the entry threshold as low as possible, the learning curve flat, and the usability of LECO modular.
 If someone wants to just connect with an Actor instance, that should be possible, and easily understood, as the Actors have a consistent API.
 This assumes that a library-specific Actor has already been written by the library maintainers.
 

--- a/glossary.md
+++ b/glossary.md
@@ -1,14 +1,14 @@
 # Glossary
 An alphabetical list of terms with a short description.
-To help distinguish between the plain English meaning of these terms, and our more specific use, we Capitalize terms from this glossary when we refer to the ECP-specific meaning.
+To help distinguish between the plain English meaning of these terms, and our more specific use, we Capitalize terms from this glossary when we refer to the LECO-specific meaning.
 
 :::{glossary}
 
 Actor
-    An Actor offers a standardized interface to the ECP network to communicate with some Device. This happens via a Driver contained in the Actor, see {ref}`components.md#actor`. An Actor implements the mapping/translation between ECP messages and the Driver's interface.
+    An Actor offers a standardized interface to the LECO network to communicate with some Device. This happens via a Driver contained in the Actor, see {ref}`components.md#actor`. An Actor implements the mapping/translation between LECO messages and the Driver's interface.
 
 Component
-    A type of entity, a set of which make up the ECP communication Network, see {ref}`components.md#components`.
+    A type of entity, a set of which make up the LECO communication Network, see {ref}`components.md#components`.
 
 Coordinator
     A Component primarily concerned with routing/coordinating the message flow, see {ref}`components.md#coordinator`.
@@ -17,21 +17,21 @@ Device
     Some piece of hardware controlled by a Driver.
 
 Director
-    A Component which takes part in orchestrating a (i.e. ECP-controlled) measurement setup, see {ref}`components.md#director`.
+    A Component which takes part in orchestrating a (i.e. LECO-controlled) measurement setup, see {ref}`components.md#director`.
 
 Driver
-    An object that takes care of communicating with a Device. This object is external to ECP, for example coming from and instrument control library like `pymeasure`, `instrumentkit` or `yaq`. See {ref}`components.md#driver`.
+    An object that takes care of communicating with a Device. This object is external to LECO, for example coming from and instrument control library like `pymeasure`, `instrumentkit` or `yaq`. See {ref}`components.md#driver`.
 
-ECP
-    The **E**xperiment **C**ontrol **P**rotocol framework.
+LECO
+    The **L**aboratory **E**xperiment **CO**ontrol protocol framework.
 
 Network
-    The web of Components communicating with each other in an ECP deployment.
+    The web of Components communicating with each other in an LECO deployment.
 
 Observer
     A Component that receives data from other Components, e.g. for logging, storage, or plotting, see {ref}`components.md#observer`.
 
 Processor
-    A Component on the ECP network which runs some kind of processing operation on one or more inputs and produces one or more outputs. Can be stateful or stateless. See {ref}`components.md#processor`.
+    A Component on the LECO network which runs some kind of processing operation on one or more inputs and produces one or more outputs. Can be stateful or stateless. See {ref}`components.md#processor`.
 
 :::

--- a/goals.md
+++ b/goals.md
@@ -10,13 +10,13 @@ We want to enable users to pick drivers from some instrument control libraries w
 
 [PyMeasure](https://pymeasure.readthedocs.io) is our project, so we know it best, and this will surely influence the design effort.
 Also, we plan a reference implementation in Python that will also probably be primarily tested with PyMeasure.
-However, we intend PyMeasure to be only one of _many_ "customer" libraries that can interface with ECP.
+However, we intend PyMeasure to be only one of _many_ "customer" libraries that can interface with LECO.
 
 This specification will be independent of the programming language its Components are written in, so it will be possible to mix-and-match.
 Instead of implementing all the necessary Components, we want to give the communication tools to connect everything, to balance on the shoulders of giants.
 
 ## Small to medium-sized use cases
-We want ECP to serve laboratory setups of up to approximately 50 participating Components on one or more computation Nodes (e.g. personal computers) on a common network.
+We want LECO to serve laboratory setups of up to approximately 50 participating Components on one or more computation Nodes (e.g. personal computers) on a common network.
 For example, you might have up to ~dozens of instruments, a few data acquisition Components, one or several GUIs, and control Components.
 
 ## Flexible and modular
@@ -24,7 +24,7 @@ For example, you might have up to ~dozens of instruments, a few data acquisition
 
 We want people to easily be able to write their own software implementing (parts of) this protocol, for example to create just the GUI tool that they need.
 
-We want ECP to be very lightly coupled to the used software (like instrument driver libraries) -- we want to thinly wrap these with some interface code that is written (ideally) _once_.
+We want LECO to be very lightly coupled to the used software (like instrument driver libraries) -- we want to thinly wrap these with some interface code that is written (ideally) _once_.
 Given some instrument control library with a reasonably homogeneous/simple API, it should be easy to write an Actor variant to connect that library's Drivers with our Actor interface.
 
 ## Simple, yet powerful
@@ -42,7 +42,7 @@ A failing Component should not corrupt the measurement data acquired until then.
 That means that e.g. a failing Actor does not corrupt data of other Actors, and that a failing Observer has to have written the data to permanent storage before failing, e.g. by regularly writing instead of buffering a lot of data in memory.
 
 ## Onboarding experience
-We want to leave the entry threshold as low as possible, the learning curve flat, and the usability of ECP modular.
+We want to leave the entry threshold as low as possible, the learning curve flat, and the usability of LECO modular.
 
 For simple measurements, a user should just need to download a package, write a little code to connect to the hardware with an Actor and a Driver from some instrument control library (e.g. a `pymeasure.Instrument`), and measure some things using the Actor interface.
 This assumes that an Actor variant interfacing to the given instrument control library has already been implemented.


### PR DESCRIPTION
After we have agreed on the new name for the protocol and the pypi package (see #25), this replaces all "ECP" with "LECO". 