### PR TITLE
Control protocol transport layer.

### DIFF
--- a/appendix.md
+++ b/appendix.md
@@ -2,7 +2,7 @@
 
 ## ZMQ
 
-Some useful hints regarding the working of the zmq package.
+Some useful hints regarding how the zmq package works.
 
 (router-sockets)=
 ### Particularities of ROUTER sockets
@@ -10,11 +10,11 @@ Some useful hints regarding the working of the zmq package.
 A small introduction to ROUTER sockets, for more details see [zmq guide chapter 3](https://zguide.zeromq.org/docs/chapter3/#Exploring-ROUTER-Sockets).
 
 A router socket assigns a random _identity_ to each connecting peer.
-If, for example, two Components `CA`, `CB` connect to the ROUTER sockets, the socket assigns the identities, which will be called `IA`, `IB` here (they can be any byte sequence).
+If, for example, two Components `CA`, `CB` connect to a ROUTER socket, the socket assigns identities, which will be called `IA`, `IB` here (they can be any byte sequence).
 
-Whenever a message is sent to the ROUTER socket from a peer, the socket prepends that identity in front of the message frames.
-For example if `CA` sends the message `Request A`, the ROUTER socket will read `IA|Request A`.
-That way, the answer to that message can be returned to the correct peer and not another one (a ROUTER socket can have many connected peers).
+Whenever a message is sent to a ROUTER socket from a peer, the socket prepends that identity in front of the message frames, before handing the message to the application code.
+For example, if `CA` sends the message `Request A`, the ROUTER socket will read `IA|Request A`.
+That way, an answer to that message can be returned to this same peer, and not another one (a ROUTER socket may have many connected peers).
 If the ROUTER's send command is called with `IA|Reply A`, the socket will send `Reply A` to the peer, whose connection is `IA`, in this case `CA`.
 
 The following diagram shows this example communication with two Components:

--- a/appendix.md
+++ b/appendix.md
@@ -1,8 +1,10 @@
 # Appendix
 
+
 ## ZMQ
 
 Some useful hints regarding how the zmq package works.
+
 
 (router-sockets)=
 ### Particularities of ROUTER sockets

--- a/appendix.md
+++ b/appendix.md
@@ -1,0 +1,34 @@
+# Appendix
+
+## ZMQ
+
+Some useful hints regarding the working of the zmq package.
+
+(router-sockets)=
+### Particularities of ROUTER sockets
+
+A small introduction to ROUTER sockets, for more details see [zmq guide chapter 3](https://zguide.zeromq.org/docs/chapter3/#Exploring-ROUTER-Sockets).
+
+A router socket assigns a random _identity_ to each connecting peer.
+If, for example, two Components `CA`, `CB` connect to the ROUTER sockets, the socket assigns the identities, which will be called `IA`, `IB` here (they can be any byte sequence).
+
+Whenever a message is sent to the ROUTER socket from a peer, the socket prepends that identity in front of the message frames.
+For example if `CA` sends the message `Request A`, the ROUTER socket will read `IA|Request A`.
+That way, the answer to that message can be returned to the correct peer and not another one (a ROUTER socket can have many connected peers).
+If the ROUTER's send command is called with `IA|Reply A`, the socket will send `Reply A` to the peer, whose connection is `IA`, in this case `CA`.
+
+The following diagram shows this example communication with two Components:
+sequenceDiagram
+    participant Code as Message handling
+    participant ROUTER as ROUTER socket
+    Note over Code, ROUTER: Coordinator
+    CA ->> ROUTER: "Request A"
+    ROUTER ->> Code: "IA|Request A"
+    Code ->> ROUTER: "IA|Reply A"
+    ROUTER ->> CA: "Reply A"
+    CB ->> ROUTER: "Request B"
+    ROUTER ->> Code: "IB|Request B"
+    Code ->> ROUTER: "IB|Reply B"
+    ROUTER ->> CB: "Reply B"
+:::
+

--- a/appendix.md
+++ b/appendix.md
@@ -9,13 +9,16 @@ Some useful hints regarding how the zmq package works.
 
 A small introduction to ROUTER sockets, for more details see [zmq guide chapter 3](https://zguide.zeromq.org/docs/chapter3/#Exploring-ROUTER-Sockets).
 
-A router socket assigns a random _identity_ to each connecting peer.
+The ROUTER socket is mostly used in a server role as it can maintain connections to many peers.
+In order to distinguish peers, it assigns a random _identity_ to each connected peer.
+Application code does not know, which peer gets which identity, however, the identity of a peer stays the same for the lifetime of the connection.
+
 If, for example, two Components `CA`, `CB` connect to a ROUTER socket, the socket assigns identities, which will be called `IA`, `IB` here (they can be any byte sequence).
 
 Whenever a message is sent to a ROUTER socket from a peer, the socket prepends that identity in front of the message frames, before handing the message to the application code.
 For example, if `CA` sends the message `Request A`, the ROUTER socket will read `IA|Request A`.
 That way, an answer to that message can be returned to this same peer, and not another one (a ROUTER socket may have many connected peers).
-If the ROUTER's send command is called with `IA|Reply A`, the socket will send `Reply A` to the peer, whose connection is `IA`, in this case `CA`.
+Consequently, in order to send such an answer, the identity has to be prepended to the frames to send: Calling the ROUTER's send command with `IA|Reply A`, the socket will send `Reply A` to the peer, whose identity is `IA`, in this case that is `CA`.
 
 The following diagram shows this example communication with two Components:
 sequenceDiagram

--- a/appendix.md
+++ b/appendix.md
@@ -6,8 +6,7 @@
 Some useful hints regarding how the zmq package works.
 
 
-(router-sockets)=
-### Particularities of ROUTER sockets
+### ROUTER sockets
 
 A small introduction to ROUTER sockets, for more details see [zmq guide chapter 3](https://zguide.zeromq.org/docs/chapter3/#Exploring-ROUTER-Sockets).
 

--- a/appendix.md
+++ b/appendix.md
@@ -11,7 +11,7 @@ A small introduction to ROUTER sockets, for more details see [zmq guide chapter 
 
 The ROUTER socket is mostly used in a server role as it can maintain connections to many peers.
 In order to distinguish peers, it assigns a random _identity_ to each connected peer.
-Application code does not know, which peer gets which identity, however, the identity of a peer stays the same for the lifetime of the connection.
+Application code does not know which peer gets which identity, however, the identity of a peer stays the same for the lifetime of the connection.
 
 If, for example, two Components `CA`, `CB` connect to a ROUTER socket, the socket assigns identities, which will be called `IA`, `IB` here (they can be any byte sequence).
 

--- a/conf.py
+++ b/conf.py
@@ -18,7 +18,7 @@ extensions = ['myst_parser', 'sphinxcontrib.mermaid', 'sphinx_rtd_theme']
 myst_enable_extensions = [
   "colon_fence",
 ]
-myst_heading_anchors = 4
+myst_heading_anchors = 5
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/conf.py
+++ b/conf.py
@@ -18,7 +18,7 @@ extensions = ['myst_parser', 'sphinxcontrib.mermaid', 'sphinx_rtd_theme']
 myst_enable_extensions = [
   "colon_fence",
 ]
-myst_heading_anchors = 3
+myst_heading_anchors = 4
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -255,6 +255,10 @@ The sign-out might happen because the Coordinator shuts down.
 
 These are the sign-in/sign-out sequences between Coordinators, where `address` is for example the host name and port number of the Coordinator's ROUTER socket.
 
+In this diagram, the Namespaces (`N1`, `N2`) are added for clarity.
+They are transmitted in the sender frame.
+For example `ACK: Namespace is N2` is transmitted as `V|N1.COORDINATOR|N2.COORDINATOR|H|ACK`.
+
 :::{mermaid}
 sequenceDiagram
     participant r1 as ROUTER
@@ -297,11 +301,11 @@ sequenceDiagram
 The sign-in procedure is symmetric, with exception of not creating a DEALER socket, if it already exists.
 :::
 
-These are the decision processes for signing in:
+These are the decision processes of `N1`'s Coordinator (at `address1`) for signing in:
 :::{mermaid}
 graph TD
-    COS([ROUTER receives<br>'CO_SIGNIN N2 address2']) --> Store[Store the identity of 'N2']
-    Store --> ACK[Respond 'ACK N1'<br>via ROUTER]
+    COS([ROUTER receives<br>'CO_SIGNIN address2'<br>from N2.COORDINATOR]) --> Store[Store the identity of 'N2']
+    Store --> ACK[Respond 'ACK'<br>via ROUTER]
     ACK-->DEAL{DEALER socket<br>with name 'N2'<br>already created?}
     DEAL -->|yes| END([End])
     DEAL -->|no| CREATE[Create DEALER<br>named 'N2']
@@ -310,10 +314,10 @@ graph TD
     CMD([Command to sign in<br>to address2])-->CREATE2[Create DEALER<br>named 'temp-NS']
     CREATE2 --> CONNECT
 
-    CONNECT-->SEND[Send 'CO_SIGNIN N1 address1']
+    CONNECT-->SEND[Send 'CO_SIGNIN address1']
     SEND --> END
 
-    AR(['ACK N2' <br>at DEALER]) --> Known{DEALER name == 'N2'?}
+    AR(['ACK' from N2.COORDINATOR<br>at DEALER socket]) --> Known{DEALER name == 'N2'?}
     Known -->|no| Rename[Rename DEALER socket to 'N2'] -->SLD
     Known -->|yes| SLD([Send my local Directory])
 :::
@@ -340,8 +344,6 @@ The other Coordinators shall update their global Directory according to this mes
 - PING
 - CO_SIGNIN
 - CO_SIGNOUT
-- CO_TELL_ALL
-- CO_NEW
 - CO_UPDATE
 
 

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -80,7 +80,7 @@ COORDINATOR is a placeholder for the final version.
 Also every Node ID has to be unique in the Network.
 As each Component belongs to exactly one Coordinator, it is fully identified by the combination of Node ID and Component ID., which is globally unique.
 This _full ID_ is the composition of Node ID, ".", and Component ID.
-For example `Co1.CA` is the full ID of the Component `CA` in the Node `Co1`.
+For example `N1.CA` is the full ID of the Component `CA` in the Node `N1`.
 
 The receiver of a message may be specified without the Node ID, if the receiver lives in the same Node.
 
@@ -105,7 +105,7 @@ The _global address book_ is the combination of the local address books of all C
 ### Conversation protocol
 
 In the protocol examples, `CA`, `CB`, etc. indicate Component IDs.
-`Co1`, `Co2`, etc. indicate Coordinators with their Node IDs.
+`N1`, `N2`, etc. indicate Node IDs and `Co1`, `Co2` their corresponding Coordinators.
 
 Here the Message content is expressed in plain English, for the exact definition see {ref}`message-layer`.
 
@@ -127,21 +127,22 @@ If a Component does send a message to someone without having signed in, the Coor
 
 :::{mermaid}
 sequenceDiagram
-    Note over CA,Co1: ID "CA" is still free
-    CA ->> Co1: COORDINATOR|CA|SIGNIN
-    Note right of Co1: Connection identity "IA"
-    Note right of Co1: Stores "CA" with identity "IA"
-    Co1 ->> CA: Co1.CA|Co1.COORDINATOR|ACKNOWLEDGE: Node ID is "Co1"
-    Note left of CA: Stores "Co1" as Node ID
-    Note over CA,Co1: ID "CA" is already used
-    CA ->> Co1: COORDINATOR|CA|SIGNIN
-    Co1 ->> CA: CA|Co1.COORDINATOR|ERROR: ID "CA" is already used.
+    Note over CA,N1: ID "CA" is still free
+    participant N1 as N1.COORDINATOR
+    CA ->> N1: COORDINATOR|CA|SIGNIN
+    Note right of N1: Connection identity "IA"
+    Note right of N1: Stores "CA" with identity "IA"
+    N1 ->> CA: N1.CA|N1.COORDINATOR|ACKNOWLEDGE: Node ID is "N1"
+    Note left of CA: Stores "N1" as Node ID
+    Note over CA,N1: ID "CA" is already used
+    CA ->> N1: COORDINATOR|CA|SIGNIN
+    N1 ->> CA: CA|N1.COORDINATOR|ERROR: ID "CA" is already used.
     Note left of CA: May retry with another ID
-    Note over CA,Co1: "CA" has not send SIGNIN
+    Note over CA,N1: "CA" has not send SIGNIN
     Note left of CA: Wants to send a message to CB
-    CA ->> Co1: Co1.CB|CA|Content
-    Note right of Co1: Does not know CA
-    Co1 ->> CA: CA|Co1.COORDINATOR|ERROR:I do not know you
+    CA ->> N1: N1.CB|CA|Content
+    Note right of N1: Does not know CA
+    N1 ->> CA: CA|N1.COORDINATOR|ERROR:I do not know you
     Note left of CA: Should send a SIGNIN message
 :::
 
@@ -169,9 +170,10 @@ It shall also publish to the other Coordinators in the network that this Compone
 
 :::{mermaid}
 sequenceDiagram
-    CA ->> Co1: COORDINATOR|Co1.CA|SIGNOUT
-    Co1 ->> CA: Co1.CA|Co1.COORDINATOR|ACKNOWLEDGE
-    Note right of Co1: Removes "CA" with identity "IA"<br> from address book
+    CA ->> N1: COORDINATOR|N1.CA|SIGNOUT
+    participant N1 as N1.COORDINATOR
+    N1 ->> CA: N1.CA|N1.COORDINATOR|ACKNOWLEDGE
+    Note right of N1: Removes "CA" with identity "IA"<br> from address book
     Note left of CA: Shall not send any message anymore except SIGNIN
 :::
 
@@ -187,28 +189,31 @@ Coordinators shall hand on the message to the corresponding Coordinator or conne
 :::{mermaid}
 sequenceDiagram
     alt full ID
-        CA ->> Co1: Co1.CB|Co1.CA| Give me property A.
+        CA ->> N1: N1.CB|N1.CA| Give me property A.
     else only Component ID
-        CA ->> Co1: CB|Co1.CA| Give me property A.
+        CA ->> N1: CB|N1.CA| Give me property A.
     end
-    Co1 ->> CB: Co1.CB|Co1.CA| Give me property A.
+    participant N1 as N1.COORDINATOR
+    N1 ->> CB: N1.CB|N1.CA| Give me property A.
     Note left of CB: Reads property A
-    CB ->> Co1: Co1.CA|Co1.CB| Property A has value 5.
-    Co1 ->> CA: Co1.CA|Co1.CB| Property A has value 5.
+    CB ->> N1: N1.CA|N1.CB| Property A has value 5.
+    N1 ->> CA: N1.CA|N1.CB| Property A has value 5.
 :::
 
 
 :::{mermaid}
 sequenceDiagram
-    CA ->> Co1: Co2.CB|Co1.CA| Give me property A.
-    Note over Co1,Co2: Co1.DEALER socket sends to Co2.ROUTER
-    Co1 ->> Co2: Co2.CB|Co1.CA| Give me property A.
-    Co2 ->> CB: Co2.CB|Co1.CA| Give me property A.
+    CA ->> N1: N2.CB|N1.CA| Give me property A.
+    participant N1 as N1.COORDINATOR
+    Note over N1,N2: N1 DEALER socket sends to N2 ROUTER
+    participant N2 as N2.COORDINATOR
+    N1 ->> N2: N2.CB|N1.CA| Give me property A.
+    N2 ->> CB: N2.CB|N1.CA| Give me property A.
     Note left of CB: Reads property A
-    CB ->> Co2: Co1.CA|Co2.CB| Property A has value 5.
-    Note over Co1,Co2: Co2.DEALER socket sends to Co1.ROUTER
-    Co2 ->> Co1: Co1.CA|Co2.CB| Property A has value 5.
-    Co1 ->> CA: Co1.CA|Co2.CB| Property A has value 5.
+    CB ->> N2: N1.CA|N2.CB| Property A has value 5.
+    Note over N1,N2: N2 DEALER socket sends to N1 ROUTER
+    N2 ->> N1: N1.CA|N2.CB| Property A has value 5.
+    N1 ->> CA: N1.CA|N2.CB| Property A has value 5.
 :::
 
 Prerequisite of Communication between two Components are:

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -26,24 +26,28 @@ This DEALER socket shall connect to the other Coordinator's ROUTER socket.
 While the number of DEALER sockets thus required scales badly with the number of Connectors in a LECO Network, the scope of the protocol means that at most a few Coordinators will be involved.
 :::
 
-Messages must be sent to a Coordinator's ROUTER socket.
+Communicating with a Coordinator, messages must be sent to a Coordinator's ROUTER socket.
+Only for acknowledging a {ref}`coordinator-sign-in`, it is permitted to send a message to a Coordinator's DEALER socket.
 
 
 #### Naming scheme
 
 Each Component must have an individual name, given by the user, the _Component name_.
-A Component name must be a series of bytes, without the ASCII character "." (the byte value 46 is not permitted).
+A Component name must be a series of ASCII characters, without the character ".".
 Component names must be unique in a {ref}`Node <network-structure.md#node>`, i.e. among the Components (except other Coordinators) connected to a single Coordinator.
-A Coordinator itself must have the Component name `COORDINATOR` (ASCII encoded).
+A Coordinator itself must have the Component name `COORDINATOR`.
 
 Similarly, every Node must have a name, the _Namespace_.
 Every Namespace must be unique in the Network.
+It must be a series of ASCII characters, without the character ".".
 As each Component belongs to exactly one Node, it is fully identified by the combination of Namespace and Component name, which is globally unique.
 This _Full name_ is the composition of Namespace, ".", and Component name.
 For example `N1.CA` is the Full name of the Component `CA` in the Node `N1`.
 
 The receiver of a message may be specified by Component name alone if the receiver belongs to the same Node as the sender.
 In all other cases, the receiver of a message must be specified by the Full name.
+
+The sender of a message must be specified by Full name, except during SIGNIN, when the Component name alone is sufficient.
 
 
 #### Message composition
@@ -146,7 +150,6 @@ sequenceDiagram
 #### Communication with other Components
 
 The following two examples show how a message is transferred between two components `CA`, `CB` via one or two Coordinators.
-Coordinators shall send messages from their DEALER socket to other Coordinator's ROUTER socket.
 
 Coordinators shall route the message to the corresponding Coordinator or connected Component.
 

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -1,0 +1,232 @@
+# Control protocol
+
+The control protocol transmits messages via its {ref}`transport-layer` from one Component to another one.
+The {ref]}`message-layer` is the common language to understand commands, thus creating a remote procedure call.
+
+
+(transport-layer)=
+## Transport layer
+
+The transport layer ensures, that a message arrives its destination.
+
+
+### Sockets and Connections
+
+We use [zmq](https://zeromq.org/) sockets for our communication. For more details see the [zmq guide](https://zguide.zeromq.org/) or [zmq API](http://api.zeromq.org/)
+
+
+#### Definitions
+
+Zmq messages consist in a series of frames, each is a byte sequence.
+We indicate the separation between frames with `|`.
+An empty frame is indicated with two frame separators `||`, even at the beginning or end of a message.
+For example `||Second frame|Third frame||Fifth frame` consists of 5 frames.
+The first and fourth frames are empty frames.
+
+
+#### Configuration
+
+Each {ref}`Coordinator <components.md#coordinator>` shall offer one ROUTER socket, bound to a host name (or IP address or any address of a computer with "*") and port in the DMT.
+
+{ref}`Components <components.md#components>` shall have one DEALER socket connecting to one Coordinator's ROUTER socket.
+
+Coordinators shall have one DEALER socket per other Coordinator in the network.
+This DEALER socket shall connect to the other Coordinator's ROUTER socket.
+
+Messages must be sent to a Coordinator's ROUTER socket.
+
+
+#### Particularities of ROUTER sockets
+
+A small introduction to ROUTER sockets, for more details see [zmq guide chapter 3](https://zguide.zeromq.org/docs/chapter3/#Exploring-ROUTER-Sockets).
+
+A router socket assigns a random identity to each connecting peer.
+If, for example, two Components `CA`, `CB` connect to the ROUTER sockets, the socket assigns the identities, which we call `IA`, `IB` (they can be any bytes sequence).
+
+Whenever a message is sent to the ROUTER socket from a peer, it reads as a first frame that identity.
+For example if `CA` sends the message `Request A`, the ROUTER socket will read `IA|Request A`.
+That way, you can return an answer to exactly the original peer and not, for example `CB`.
+If you call the ROUTER's send command with `IA|Reply A`, the socket will send `Reply A` to the peer, whose connection is `IA`, in this case `CA`.
+
+The following diagram shows this example communication with two Components:
+:::{mermaid}
+graph TD
+    CA([CA]) -->|"Request A"| D[recv] -->|"IA|Request A"| A([Coordinator])
+    CB([CB]) -->|"Request B"| C[recv] -->|"IB|Request B"| A
+    subgraph ROUTER socket
+        B
+        C
+        D
+        E
+    end
+    A -. "IA|Reply A" .-> B
+    B[send] -. "Reply A" .-> CA
+    A -. "IB|Reply B" .-> E
+    E[send] -. "Reply B" .-> CB
+:::
+
+
+### Naming scheme
+
+Each Component has an individual ID, given by the user, the Component ID.
+A Component ID must be a series of bytes, without the ASCII character "." (byte value 46).
+Component IDs must be unique in a Node, i.e. among the Componets connected to a single Coordinator.
+
+As each Component belongs to exactly one Coordinator, it is fully identified by the combination of Node ID and Component ID.
+This _full ID_ is the composition of Node ID, ".", and Component ID.
+
+The receiver of a message may be specified without the Node ID, if the receiver lives in the same Node.
+
+:::{note}
+How to address the Coordinator? I used "no Recipient".
+Or a fixed name?
+:::
+
+
+### Message composition
+
+A message consists in two or more frames.
+1. The receiver full ID.
+2. The sender full ID.
+3. Message content: The optional payload, which can be 0 or more frames.
+
+
+### Conversation protocol
+
+In the protocol examples, `CA`, `CB`, etc. indicate Components.
+`Co1`, `Co2`, etc. indicate Coordinators.
+
+Here the Message content is expressed in plain English, for the exact definition see {ref}`message-layer`.
+
+In the exchange of messages, only the messages over the wire are shown, the connection identity of the ROUTER socket is not shown.
+
+
+#### Communication with the Coordinator
+
+##### Initial connection
+
+After connecting to a Coordinator (`Co1`), a Component (`CA`) shall send a CONNECT message indicating its ID.
+The Coordinator shall respond with an ACKNOWLEDGE, giving the Node ID and other relevant information, or with an ERROR, if the ID is already taken.
+After that successful handshake, the Coordinator shall store the connection identity and correspondind Component ID in its address book.
+:::{note}
+publish that information
+:::
+Similarly, the Component shall store the Node ID and use it from this moment to generate its full ID.
+
+:::{mermaid}
+sequenceDiagram
+    Note over CA,Co1: ID "CA" is still free
+    CA ->> Co1: ||CA|CONNECT
+    Note right of Co1: Connection identity "IA"
+    Note right of Co1: Stores "CA" with identity "IA"
+    Co1 ->> CA: Co1.CA||ACKNOWLEDGE: Node ID is "Co1"
+    Note left of CA: Stores "Co1" as Node ID
+    Note over CA,Co1: ID "CA" is already used
+    CA ->> Co1: ||CA|CONNECT
+    Co1 ->> CA: CA||ERROR: ID "CA" is already used.
+    Note left of CA: May retry with another ID
+:::
+
+
+##### Heartbeat
+
+We use heartbeat to know, whether a communication partner is still online.
+
+Every message received counts as a heartbeat.
+
+:::{note}
+TBD: Respond to every non empty message with an empty one?
+:::
+
+
+##### Disconnecting
+
+A Component should tell a Coordinator, when it stops working, with a DISCONNECT message.
+The Coordinator shall ACKNOWLEDGE the disconnect and remove the ID from its address book.
+:::{note}
+publish that information
+:::
+
+:::{mermaid}
+sequenceDiagram
+    CA ->> Co1: ||Co1.CA|DISCONNECT
+    Co1 ->> CA: Co1.CA||ACKNOWLEDGE
+    Note right of Co1: Removes "CA" with identity "IA"<br> from address book
+    Note left of CA: Shall not send any message anymore
+:::
+
+
+#### Communication with other Components
+
+The following two examples show, how a message is transferred between two components `CA`, `CB` via one or two Coordinators.
+Coordinators shall send messages from their DEALER socket to other Coordinator's ROUTER socket.
+
+Coordinators shall hand on the message to the corresponding Coordinator or connected Component.
+
+
+:::{mermaid}
+sequenceDiagram
+    CA ->> Co1: Co1.CB|Co1.CA| Give me property A.
+    Co1 ->> CB: Co1.CB|Co1.CA| Give me property A.
+    Note left of CB: Reads property A
+    CB ->> Co1: Co1.CA|Co1.CB| Property A has value 5.
+    Co1 ->> CA: Co1.CA|Co1.CB| Property A has value 5.
+    Note over CA,Co1: The first message could be as well:
+    CA ->> Co1: CB|Co1.CA| Give me property A.
+:::
+
+
+:::{mermaid}
+sequenceDiagram
+    CA ->> Co1: Co2.CB|Co1.CA| Give me property A.
+    Note over Co1,Co2: Co1.DEALER socket sends to Co2.ROUTER
+    Co1 ->> Co2: Co2.CB|Co1.CA| Give me property A.
+    Co2 ->> CB: Co2.CB|Co1.CA| Give me property A.
+    Note left of CB: Reads property A
+    CB ->> Co2: Co1.CA|Co2.CB| Property A has value 5.
+    Note over Co1,Co2: Co2.DEALER socket sends to Co1.ROUTER
+    Co2 ->> Co1: Co1.CA|Co2.CB| Property A has value 5.
+    Co1 ->> CA: Co1.CA|Co2.CB| Property A has value 5.
+:::
+
+
+The following flow chart shows the decision scheme and message modification in a Coordinator.
+`IA` and `IB` are the connection identities of `CA` and `Co1.Recipient`.
+Bold arrows indicate message flow, thin lines indicate decision flow.
+
+:::{mermaid}
+flowchart TB
+    C([CA DEALER]) == "NodeID.Recipient|Co1.CA|Content" ==> R0
+    R0[Co1 ROUTER receive] == "IA|NodeID.Recipient|Co1.CA|Content" ==> Code[remove sender identity]
+    Code == "NodeID.Recipient|Co1.CA|Content" ==> NS
+    NS -- "is None" --> Local
+    NS{NodeID} -- "== Co1"--> Local
+    Local{Recipient<br> is None} -- "yes" --> Self([Message for Co1<br> itself])
+    Local -- "no" --> Local2
+    Local2[add Recipient identity IB] == "IB|NodeID.Recipient|Co1.CA|Content" ==> R1[send]
+    R1 == "NodeID.Recipient|Co1.CA|Content" ==> W1([Wire to Co1.Recipient DEALER])
+    NS -- "== connected Coordinator Co2" --> Keep
+    Keep[send to Coordinator Co2] == "NodeID.Recipient|Co1.CA|Content" ==> R2[send]
+    R2 == "NodeID.Recipient|Co1.CA|Content" ==> W2([Wire to Co2 ROUTER])
+    NS -- "reachable via Coordinator CoX" --> Augment
+    Augment[send via CoX] == "NodeID.Recipient|Co1.CA|Content" ==> R3[send]
+    R3 == "NodeID.Recipient|Co1.CA|Content"==> W3([Wire to CoX ROUTER])
+    subgraph Co1 ROUTER socket
+        R1
+    end
+    subgraph Co1 DEALER socket to Co2
+        R2
+    end
+    subgraph Co1 DEALER socket to CoX
+        R3
+    end
+:::
+
+
+
+(message-layer)=
+## Message layer
+
+:::{note}
+TODO
+:::

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -238,7 +238,7 @@ flowchart TB
 
 #### Coordinator coordination
 
-Each Coordinator shall keep an up-to-date global {ref}`directory` with the Names of all Components in the Network.
+Each Coordinator shall keep an up-to-date global {ref}`directory` with the Full names of all Components in the Network.
 For this, Coordinators shall notify each other about sign-ins and sign-outs of Components and Coordinators.
 On request, Coordinators shall send the Names of their local or global Directory, depending on the request type.
 

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -1,6 +1,6 @@
 # Control protocol
 
-The control protocol transmits messages via its {ref}`transport-layer` from one Component to another one.
+The control protocol transmits messages via its {ref}`transport-layer` from one Component to another.
 The {ref]}`message-layer` is the common language to understand commands, thus creating a remote procedure call.
 
 
@@ -15,7 +15,7 @@ The transport layer ensures that a message arrives at its destination.
 #### Socket Configuration
 
 Each {ref}`Coordinator <components.md#coordinator>` shall offer one {ref}`ROUTER<appendix.md#router-sockets>` socket, bound to an address.
-The address consists of a host (this can be the host name, an IP address of the device, or "\*" for all IP addresses of the device) and a port number, for example `*:12345` for all IP addresses and the port `12345`.
+The address consists of a host (this can be the host name, an IP address of the device, or "\*" for all IP addresses of the device) and a port number, for example `*:12345` for all IP addresses at the port `12345`.
 
 {ref}`Components <components.md#components>` shall have one DEALER socket connecting to one Coordinator's ROUTER socket.
 
@@ -32,7 +32,7 @@ Messages must be sent to a Coordinator's ROUTER socket.
 #### Naming scheme
 
 Each Component must have an individual name, given by the user, the _Component name_.
-A Component name must be a series of bytes, without the ASCII character "." (byte value 46).
+A Component name must be a series of bytes, without the ASCII character "." (the byte value 46 is not permitted).
 Component names must be unique in a {ref}`Node <network-structure.md#node>`, i.e. among the Components (except other Coordinators) connected to a single Coordinator.
 A Coordinator itself must have the Component name `COORDINATOR` (ASCII encoded).
 
@@ -43,7 +43,7 @@ This _Full name_ is the composition of Namespace, ".", and Component name.
 For example `N1.CA` is the Full name of the Component `CA` in the Node `N1`.
 
 The receiver of a message may be specified by Component name alone if the receiver belongs to the same Node as the sender.
-In all other cases, the receiver of a message must be specified by Full name.
+In all other cases, the receiver of a message must be specified by the Full name.
 
 
 #### Message composition
@@ -81,12 +81,12 @@ In the exchange of messages, only the messages over the wire are shown, the conn
 
 After connecting to a Coordinator (`Co1`), a Component (`CA`) shall send a SIGNIN message indicating its Component name.
 The Coordinator shall indicate success/acceptance with an ACKNOWLEDGE response, giving the Namespace and other relevant information, or reply with an ERROR, e.g. if the Component name is already taken.
-In that case, the Coordinator may indicate a suitable still available variation on the indicated Component name.
+In that case, the Coordinator may indicate a suitable, still available variation on the indicated Component name.
 The Component may retry SIGNIN with a different chosen name.
 
 After a successful handshake, the Coordinator shall store the (zmq) connection identity and corresponding Component name in its {ref}`directory`.
 It shall also notify the other Coordinators in the network that this Component signed in, see {ref}`Coordinator coordination<coordinator-coordination>`.
-Similarly, the Component shall store the Namespace and use it from this moment to generate its Full name.
+Similarly, the Component shall store the Namespace and use it from this moment on, to generate its Full name.
 
 If a Component does send a message to someone without having signed in, the Coordinator shall refuse message handling and return an error.
 
@@ -129,7 +129,7 @@ TBD: Respond to every non empty message with an empty one?
 ##### Signing out
 
 A Component should tell a Coordinator when it stops participating in the network with a SIGNOUT message.
-The Coordinator shall ACKNOWLEDGE the sign-out and remove the Name from its Directory.
+The Coordinator shall ACKNOWLEDGE the sign-out and remove the Component name from its Directory.
 It shall also notify the other Coordinators in the network that this Component signed out, see {ref}`Coordinator coordination<coordinator-coordination>`.
 
 :::{mermaid}
@@ -186,7 +186,7 @@ Prerequisites of Communication between two Components are:
 - Both Components are either connected to the same Coordinator (example one), or their Coordinators are connected to each other (example two).
 
 
-The following flow chart shows the decision scheme and message modification in a Coordinator `Co1` of Node `N1`.
+The following flow chart shows the decision scheme and message modification in the Coordinator `Co1` of Node `N1`.
 Its Full name is `N1.Coordinator`.
 `nS`, `nR` are placeholders for sender and recipient Namespaces.
 `recipient` is a placeholder for the recipient Component name.
@@ -237,14 +237,14 @@ flowchart TB
 
 Each Coordinator shall keep an up-to-date {ref}`Glossary<directory>` with the Names of all Components in the Network.
 For this, Coordinators shall notify each other about sign-ins and sign-outs of Components and Coordinators.
-On request, Coordinators shall send the Names of their Directory, or of their Glossary, depending on the request type.
+On request, Coordinators shall send the Names of their local or global Directory, depending on the request type.
 
 For the format of the Messages, see {ref}`message-layer`.
 
 
 ##### Coordinator sign-in
 
-A Coordinator `Co1`joining a network follows a few steps:
+A Coordinator `Co1` joining a network follows a few steps:
 1. It signs in to one Coordinator `Co2` of the Network.
 2. It sends a CO_TELL_ALL message to `Co2`, to tell all other Coordinators about `Co1`s address.
 3. `Co2` tells all the Coordinators signed in (`Co3`, `Co4`...) about `Co1` with a CO_NEW message.
@@ -297,9 +297,9 @@ sequenceDiagram
 
 ##### Coordinator updates
 
-Whenever a Component signs in to or out of its Coordinator, the Coordinator shall send a CO_UPDATE message regarding this event to all the other Coordinators.
+Whenever a Component signs in to or out from its Coordinator, the Coordinator shall send a CO_UPDATE message regarding this event to all the other Coordinators.
 The message shall contain the Full name of the Component and the event type (sign in or out)
-The other Coordinators shall update their Glossary according to this message (add or remove an entry).
+The other Coordinators shall update their global Directory according to this message (add or remove an entry).
 
 
 (message-layer)=

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -50,20 +50,18 @@ That way, you can return an answer to exactly the original peer and not, for exa
 If you call the ROUTER's send command with `IA|Reply A`, the socket will send `Reply A` to the peer, whose connection is `IA`, in this case `CA`.
 
 The following diagram shows this example communication with two Components:
-:::{mermaid}
-graph TD
-    CA([CA]) -->|"Request A"| D[recv] -->|"IA|Request A"| A([Coordinator])
-    CB([CB]) -->|"Request B"| C[recv] -->|"IB|Request B"| A
-    subgraph ROUTER socket
-        B
-        C
-        D
-        E
-    end
-    A -. "IA|Reply A" .-> B
-    B[send] -. "Reply A" .-> CA
-    A -. "IB|Reply B" .-> E
-    E[send] -. "Reply B" .-> CB
+sequenceDiagram
+    participant Code
+    participant ROUTER as ROUTER socket
+    Note over Code, ROUTER: Coordinator
+    CA ->> ROUTER: "Request A"
+    ROUTER ->> Code: "IA|Request A"
+    Code ->> ROUTER: "IA|Reply A"
+    ROUTER ->> CA: "Reply A"
+    CB ->> ROUTER: "Request B"
+    ROUTER ->> Code: "IB|Request B"
+    Code ->> ROUTER: "IB|Reply B"
+    ROUTER ->> CB: "Reply B"
 :::
 
 
@@ -174,7 +172,7 @@ sequenceDiagram
     CA ->> Co1: COORDINATOR|Co1.CA|SIGNOUT
     Co1 ->> CA: Co1.CA|Co1.COORDINATOR|ACKNOWLEDGE
     Note right of Co1: Removes "CA" with identity "IA"<br> from address book
-    Note left of CA: Shall not send any message anymore
+    Note left of CA: Shall not send any message anymore except SIGNIN
 :::
 
 
@@ -188,13 +186,15 @@ Coordinators shall hand on the message to the corresponding Coordinator or conne
 
 :::{mermaid}
 sequenceDiagram
-    CA ->> Co1: Co1.CB|Co1.CA| Give me property A.
+    alt full ID
+        CA ->> Co1: Co1.CB|Co1.CA| Give me property A.
+    else only Component ID
+        CA ->> Co1: CB|Co1.CA| Give me property A.
+    end
     Co1 ->> CB: Co1.CB|Co1.CA| Give me property A.
     Note left of CB: Reads property A
     CB ->> Co1: Co1.CA|Co1.CB| Property A has value 5.
     Co1 ->> CA: Co1.CA|Co1.CB| Property A has value 5.
-    Note over CA,Co1: The first message could be as well:
-    CA ->> Co1: CB|Co1.CA| Give me property A.
 :::
 
 

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -26,11 +26,11 @@ The first and fourth frames are empty frames.
 
 #### Configuration
 
-Each {ref}`Coordinator <components.md#coordinator>` shall offer one ROUTER socket, bound to a host name (or IP address or any address of a computer with "*") and port in the DMT.
+Each {ref}`Coordinator <components.md#coordinator>` shall offer one ROUTER socket, bound to a host name (or IP address or any address of a computer with "*") and port.
 
 {ref}`Components <components.md#components>` shall have one DEALER socket connecting to one Coordinator's ROUTER socket.
 
-Coordinators shall have one DEALER socket per other Coordinator in the network.
+Coordinators shall have one DEALER socket per other Coordinator in the Network.
 This DEALER socket shall connect to the other Coordinator's ROUTER socket.
 
 Messages must be sent to a Coordinator's ROUTER socket.
@@ -73,13 +73,14 @@ graph TD
 
 Each Component has an individual ID, given by the user, the _Component ID_.
 A Component ID must be a series of bytes, without the ASCII character "." (byte value 46).
-Component IDs must be unique in a Node, i.e. among the Componets connected to a single Coordinator.
-The Coordinator itself has the Component ID `COORDINATOR`
+Component IDs must be unique in a {ref}`Node <network-structure.md#node>`, i.e. among the Componets connected to a single Coordinator.
+The Coordinator itself has the Component ID `COORDINATOR`.
 :::{note}
 COORDINATOR is a placeholder for the final version.
 :::
 
-As each Component belongs to exactly one Coordinator, it is fully identified by the combination of Node ID and Component ID.
+Also every Node ID has to be unique in the Network.
+As each Component belongs to exactly one Coordinator, it is fully identified by the combination of Node ID and Component ID., which is globally unique.
 This _full ID_ is the composition of Node ID, ".", and Component ID.
 For example `Co1.CA` is the full ID of the Component `CA` in the Node `Co1`.
 

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -58,10 +58,10 @@ A message consists of 4 or more frames.
 
 #### Directory
 
-Each Coordinator shall have a list of the Components (including other Connectors) connected to it.
-This is its _Directory_.
+Each Coordinator shall have a list of the Components (including other Coordinators) connected to it.
+This is its _local Directory_.
 
-The _Glossary_ is the combination of the Directories of all Coordinators in a Network.
+The _global Directory_ is the combination of the Directories of all Coordinators in a Network.
 
 
 ### Conversation protocol
@@ -128,8 +128,8 @@ TBD: Respond to every non empty message with an empty one?
 
 ##### Signing out
 
-A Component should tell a Coordinator when it stops participating in the network with a SIGNOUT message.
-The Coordinator shall ACKNOWLEDGE the sign-out and remove the Component name from its Directory.
+A Component should send a SIGNOUT message to its Coordinator when it stops participating in the Network.
+The Coordinator shall ACKNOWLEDGE the sign-out and remove the Component name from its local {ref}`directory`.
 It shall also notify the other Coordinators in the network that this Component signed out, see {ref}`Coordinator coordination<coordinator-coordination>`.
 
 :::{mermaid}
@@ -137,7 +137,7 @@ sequenceDiagram
     CA ->> N1: V|COORDINATOR|N1.CA|H|SIGNOUT
     participant N1 as N1.COORDINATOR
     N1 ->> CA: V|N1.CA|N1.COORDINATOR|H|ACKNOWLEDGE
-    Note right of N1: Removes "CA" with identity "IA"<br> from Directory
+    Note right of N1: Removes "CA" with identity "IA"<br> from local Directory
     Note right of N1: Notifies other Coordinators about sign-out of "CA"
     Note left of CA: Shall not send any message anymore except SIGNIN
 :::
@@ -201,8 +201,8 @@ flowchart TB
     C0([nS.COORDINATOR DEALER]) == "V|nR.recipient|nS.CA|H|Content" ==> R0
     R0[receive] == "iA|V|nR.recipient|nS.CA|H|Content" ==> CnS{nS == N1?}
     CnS-->|no| RemIdent
-    CnS-->|yes| Clocal{CA in <br>Directory?}
-    Clocal -->|yes| CidKnown{iA is CA's identity<br> in Directory?}
+    CnS-->|yes| Clocal{CA in <br>local Directory?}
+    Clocal -->|yes| CidKnown{iA is CA's identity<br> in local Directory?}
     CidKnown -->|yes| RemIdent
     Clocal -.->|no| E1[ERROR: Sender unknown] ==>|"iA|V|nS.CA|N1.COORDINATOR|H|ERROR: Sender unknown"| S
     S[send] ==> WA([N1.CA DEALER])
@@ -212,7 +212,7 @@ flowchart TB
     CnR{nR?} -- "== N1"--> Local
     Local{recipient<br>==<br>COORDINATOR?} -- "yes" --> Self[Message for Co1<br> itself]
     Self == "V|nR.recipient|nS.CA|H|Content" ==> SC([Co1 Message handling])
-    Local -- "no" --> Local2a{recipient in Directory?}
+    Local -- "no" --> Local2a{recipient in local Directory?}
     Local2a -->|yes, with Identity iB| Local2
     Local2[add recipient identity iB] == "iB|V|nR.recipient|nS.CA|H|Content" ==> R1[send]
     R1 == "V|nR.recipient|nS.CA|H|Content" ==> W1([Wire to N1.recipient DEALER])
@@ -235,7 +235,7 @@ flowchart TB
 
 #### Coordinator coordination
 
-Each Coordinator shall keep an up-to-date {ref}`Glossary<directory>` with the Names of all Components in the Network.
+Each Coordinator shall keep an up-to-date global {ref}`directory` with the Names of all Components in the Network.
 For this, Coordinators shall notify each other about sign-ins and sign-outs of Components and Coordinators.
 On request, Coordinators shall send the Names of their local or global Directory, depending on the request type.
 
@@ -270,7 +270,7 @@ sequenceDiagram
     d1-->>r2: connect to address2
     d1->>r2: CO_SIGNIN<br>N1, address1,<br>ref:temp-NS
     par
-        d1->>r2: GET Directory
+        d1->>r2: GET local Directory
     and
         Note right of r2: stores N1 identity
         activate d2
@@ -279,12 +279,12 @@ sequenceDiagram
         d2->>r1: CO_SIGNIN<br>N2, address2<br>your ref:temp-NS
         Note right of r1: stores N2 identity
         Note left of d1: name changed<br>from "temp-NS"<br>to "N2"
-        d2->>r1: GET Directory
+        d2->>r1: GET local Directory
     end
-    d2->>r1: Here is my<br>Directory
-    Note right of r1: Updates<br>Glossary
-    d1->>r2: Here is my<br>Directory
-    Note right of r2: Updates<br>Glossary
+    d2->>r1: Here is my<br>local Directory
+    Note right of r1: Updates<br>global Directory
+    d1->>r2: Here is my<br>local Directory
+    Note right of r2: Updates<br>global Directory
     Note over r1,d2: Sign out between two Coordinators
     Note right of r1: shall sign out from N2
     d1->>r2: CO_SIGNOUT

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -72,10 +72,7 @@ sequenceDiagram
 Each Component has an individual name, given by the user, the _Component Name_.
 A Component Name must be a series of bytes, without the ASCII character "." (byte value 46).
 Component Names must be unique in a {ref}`Node <network-structure.md#node>`, i.e. among the Components connected to a single Coordinator.
-The Coordinator itself has the Component Name `COORDINATOR`.
-:::{note}
-COORDINATOR is a placeholder for the final version.
-:::
+The Coordinator itself has the Component Name `COORDINATOR` (ASCII encoded).
 
 Similarly, every node has a name, the _Namespace_.
 Every Namespace has to be unique in the Network.

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -33,13 +33,14 @@ Only for acknowledging a {ref}`control_protocol.md#coordinator-sign-in`, it is p
 #### Naming scheme
 
 Each Component must have an individual name, given by the user, the _Component name_.
-A Component name must be a series of ASCII characters, without the character ".".
 Component names must be unique in a {ref}`Node <network-structure.md#node>`, i.e. among the Components (except other Coordinators) connected to a single Coordinator.
 A Coordinator itself must have the Component name `COORDINATOR`.
 
 Similarly, every Node must have a name, the _Namespace_.
 Every Namespace must be unique in the Network.
-It must be a series of ASCII characters, without the character ".".
+
+A Component name or a Namespace must be a series of printable ASCII characters (byte values 0x20 to 0x7E), without the character "." (byte value 0x2E).
+
 As each Component belongs to exactly one Node, it is fully identified by the combination of Namespace and Component name, which is globally unique.
 This _Full name_ is the composition of Namespace, ".", and Component name.
 For example `N1.CA` is the Full name of the Component `CA` in the Node `N1`.

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -1,7 +1,7 @@
 # Control protocol
 
 The control protocol transmits messages via its {ref}`transport-layer` from one Component to another.
-The {ref]}`message-layer` is the common language to understand commands, thus creating a remote procedure call.
+The {ref}`message-layer` is the common language to understand commands, thus creating a remote procedure call.
 
 
 (transport-layer)=
@@ -12,9 +12,10 @@ The transport layer ensures that a message arrives at its destination.
 
 ### Protocol basics
 
+
 #### Socket Configuration
 
-Each {ref}`Coordinator <components.md#coordinator>` shall offer one {ref}`ROUTER<appendix.md#router-sockets>` socket, bound to an address.
+Each {ref}`Coordinator <components.md#coordinator>` shall offer one {ref}`ROUTER <appendix.md#particularities-of-router-sockets>` socket, bound to an address.
 The address consists of a host (this can be the host name, an IP address of the device, or "\*" for all IP addresses of the device) and a port number, for example `*:12345` for all IP addresses at the port `12345`.
 
 {ref}`Components <components.md#components>` shall have one DEALER socket connecting to one Coordinator's ROUTER socket.
@@ -60,6 +61,7 @@ A message consists of 4 or more frames.
 5. Message content: The optional payload, which can be 0 or more frames.
 
 
+(directory)=
 #### Directory
 
 Each Coordinator shall have a list of the Components (including other Coordinators) connected to it.
@@ -73,12 +75,18 @@ The _global Directory_ is the combination of the Directories of all Coordinators
 In the protocol examples, `CA`, `CB`, etc. indicate Component names.
 `N1`, `N2`, etc. indicate Node Namespaces and `Co1`, `Co2` their corresponding Coordinators.
 
-Here the Message content is expressed in plain English, for the exact definition see {ref}`message-layer`.
+Here the Message content is expressed in plain English and placed in the Content frame, for the exact definition see {ref}`message-layer`.
+
+:::{note}
+TBD: How to show the encoded content in the examples?
+:::
+
 
 In the exchange of messages, only the messages over the wire are shown, the connection identity used by the ROUTER socket is not shown.
 
 
 #### Communication with the Coordinator
+
 
 (sign-in)=
 ##### Initial connection
@@ -89,7 +97,7 @@ In that case, the Coordinator may indicate a suitable, still available variation
 The Component may retry SIGNIN with a different chosen name.
 
 After a successful handshake, the Coordinator shall store the (zmq) connection identity and corresponding Component name in its {ref}`directory`.
-It shall also notify the other Coordinators in the network that this Component signed in, see {ref}`Coordinator coordination<coordinator-coordination>`.
+It shall also notify the other Coordinators in the network that this Component signed in, see {ref}`coordinator-coordination`.
 Similarly, the Component shall store the Namespace and use it from this moment on, to generate its Full name.
 
 If a Component does send a message to someone without having signed in, the Coordinator shall refuse message handling and return an error.
@@ -130,11 +138,12 @@ TBD: Heartbeat details are still to be determined.
 :::
 
 
+(signing-out)=
 ##### Signing out
 
 A Component should send a SIGNOUT message to its Coordinator when it stops participating in the Network.
 The Coordinator shall ACKNOWLEDGE the sign-out and remove the Component name from its local {ref}`directory`.
-It shall also notify the other Coordinators in the network that this Component signed out, see {ref}`Coordinator coordination<coordinator-coordination>`.
+It shall also notify the other Coordinators in the network that this Component signed out, see {ref}`coordinator-coordination`.
 
 :::{mermaid}
 sequenceDiagram
@@ -236,6 +245,7 @@ flowchart TB
 :::
 
 
+(coordinator-coordination)=
 #### Coordinator coordination
 
 Each Coordinator shall keep an up-to-date global {ref}`directory` with the Full names of all Components in the Network.
@@ -245,6 +255,7 @@ On request, Coordinators shall send the Names of their local or global Directory
 For the format of the Messages, see {ref}`message-layer`.
 
 
+(coordinator-sign-in)=
 ##### Coordinator sign-in
 
 A Coordinator joins a Network by signing in to any Coordinator of that Network.

--- a/glossary.md
+++ b/glossary.md
@@ -10,6 +10,9 @@ Actor
 Component
     A type of entity, a set of which make up the LECO communication Network, see {ref}`components.md#components`.
 
+Component name
+    The individual name in a Node, under which a Component can be addressed, see {ref}`control_protocol.md#naming-scheme`.
+
 Coordinator
     A Component primarily concerned with routing/coordinating the message flow between other Components, see {ref}`components.md#coordinator`.
     There are Control Coordinators, Data Coordinators, and Logging Coordinators.
@@ -22,6 +25,10 @@ Director
 
 Driver
     An object that takes care of communicating with a Device. This object is external to LECO, for example coming from and instrument control library like `pymeasure`, `instrumentkit` or `yaq`. See {ref}`components.md#driver`.
+
+Full name
+    The name of a Component unique in the whole name.
+    It consists of the {ref}`namespace` and {ref}`component-name`, see {ref}`control_protocol.md#naming-scheme`.
 
 LECO
     The **L**aboratory **E**xperiment **CO**ntrol protocol framework.
@@ -38,6 +45,9 @@ Message Layer
 
 Message Transport Mode (LMT/DMT)
     The Node-local Message Layer can have a local or distributed mode, see {ref}`network-structure.md#message-transport-mode-lmtdmt`.
+
+Namespace
+    The name of a Node in the Network, see {ref}`control_protocol.md#naming-scheme`.
 
 Node
     A Node is a local context in which (part of) a LECO deployment runs. 

--- a/glossary.md
+++ b/glossary.md
@@ -23,6 +23,9 @@ Device
 Director
     A Component which takes part in orchestrating a (i.e. LECO-controlled) measurement setup, see {ref}`components.md#director`.
 
+Directory
+    Each Coordinator maintains a local Directory with all the Components connected to it, and a global Directory with all Components in the Network, see {ref}`control_protocol.md#directory`.
+
 Driver
     An object that takes care of communicating with a Device. This object is external to LECO, for example coming from and instrument control library like `pymeasure`, `instrumentkit` or `yaq`. See {ref}`components.md#driver`.
 

--- a/glossary.md
+++ b/glossary.md
@@ -27,7 +27,7 @@ Driver
     An object that takes care of communicating with a Device. This object is external to LECO, for example coming from and instrument control library like `pymeasure`, `instrumentkit` or `yaq`. See {ref}`components.md#driver`.
 
 Full name
-    The name of a Component unique in the whole name.
+    The name of a Component unique for the whole setup.
     It consists of the {ref}`namespace` and {ref}`component-name`, see {ref}`control_protocol.md#naming-scheme`.
 
 LECO

--- a/glossary.md
+++ b/glossary.md
@@ -24,14 +24,14 @@ Director
     A Component which takes part in orchestrating a (i.e. LECO-controlled) measurement setup, see {ref}`components.md#director`.
 
 Directory
-    Each Coordinator maintains a local Directory with all the Components connected to it, and a global Directory with all Components in the Network, see {ref}`control_protocol.md#directory`.
+    Each Coordinator maintains a local Directory with all the Components connected to it (i.e. other Coordinators and the Components of its own Node), and a global Directory with all Components in the whole Network, see {ref}`control_protocol.md#directory`.
 
 Driver
     An object that takes care of communicating with a Device. This object is external to LECO, for example coming from and instrument control library like `pymeasure`, `instrumentkit` or `yaq`. See {ref}`components.md#driver`.
 
 Full name
     The name of a Component unique for the whole setup.
-    It consists of the {ref}`namespace` and {ref}`component-name`, see {ref}`control_protocol.md#naming-scheme`.
+    It consists of the namespace and component-name, see {ref}`control_protocol.md#naming-scheme`.
 
 LECO
     The **L**aboratory **E**xperiment **CO**ntrol protocol framework.

--- a/index.rst
+++ b/index.rst
@@ -18,6 +18,7 @@
    control_protocol
    glossary
    Hello_world
+   appendix
 
 Indices and tables
 ==================

--- a/index.rst
+++ b/index.rst
@@ -13,6 +13,7 @@
    introduction
    goals
    components
+   control_protocol
    glossary
    Hello_world
 

--- a/network-structure.md
+++ b/network-structure.md
@@ -47,10 +47,25 @@ flowchart LR
 Control Coordinator to Control Coordinator communication always uses DMT.
 
 ## Message Transport Mode (LMT/DMT)
-The Node-local Message Layer can have a local or distributed mode.
-The Distributed Message Transport (DMT, using the zeromq TCP protocol) works within or across Nodes.
 
-The Local Message Transport (LMT) only works within a Node _and_ within a process.
+The Node-local Message Layer can have a local or distributed mode.
+
+### Distributed Message Transport (DMT)
+
+The Distributed Message Transport works within or across Nodes.
+It uses [Zmq](https://zeromq.org/) sockets for the communication. For more details see the [zmq guide](https://zguide.zeromq.org/) or [zmq API](http://api.zeromq.org/)
+
+Zmq messages consist in a series of frames, each is a byte sequence.
+In this documentation, the separation between frames is indicated by `|`.
+An empty frame is indicated with two frame separators `||`, even at the beginning or end of a message.
+For example, the message `||Second frame|Third frame||Fifth frame` consists of 5 frames, with the first and fourth frames being empty frames.
+
+For some useful information see our {ref}`appendix.md#zmq`.
+
+
+### Local Message Transport (LMT)
+
+The Local Message Transport only works within a Node _and_ within a process.
 Local Message Transport options include queues between threads/processes and zeromq inproc.
 :::{admonition} Warning
 LMT details are still notional and not to be relied upon this will be fleshed out at a later date. 

--- a/network-structure.md
+++ b/network-structure.md
@@ -53,7 +53,7 @@ The Node-local Message Layer can have a local or distributed mode.
 ### Distributed Message Transport (DMT)
 
 The Distributed Message Transport works within or across Nodes.
-It uses [Zmq](https://zeromq.org/) sockets for the communication. For more details see the [zmq guide](https://zguide.zeromq.org/) or [zmq API](http://api.zeromq.org/)
+Currently, the only defined transport layer uses [Zmq](https://zeromq.org/) sockets for the communication. For more details see the [zmq guide](https://zguide.zeromq.org/) or [zmq API](http://api.zeromq.org/)
 
 Zmq messages consist in a series of frames, each is a byte sequence.
 In this documentation, the separation between frames is indicated by `|`.
@@ -68,6 +68,6 @@ For some useful information see our {ref}`appendix.md#zmq`.
 The Local Message Transport only works within a Node _and_ within a process.
 Local Message Transport options include queues between threads/processes and zeromq inproc.
 :::{admonition} Warning
-LMT details are still notional and not to be relied upon this will be fleshed out at a later date. 
+LMT details are still notional and not to be relied upon, this will be fleshed out at a later date. 
 The list of LMT options is not definitive yet.
 :::


### PR DESCRIPTION
First version of the control protocol transport layer.
It is a up to date state of the current discussions regarding the control protocol in different issues.
The mermaid diagrams can be seen in #39 (in the right order)
A first rendering (if it succeeds) is in https://leco-laboratory-experiment-control-protocol--38.org.readthedocs.build/en/38/control_protocol.html

- Please use different issues for content discussion.
- Please do not remark on language, until it is "ready for review", in this first stage, we have to rig down the protocol itself.


I hope I made everything right with the formatting.

Things to determine regarding content:
- [x] How do we address the Coordinator, see #27
- [x] How do we handle heartbeats? #40 Postponed.
- [x] How to do the coordination of Coordinators (global address book)? see #22, my proposal: https://github.com/pymeasure/leco-protocol/issues/22#issuecomment-1414403570 

What are your ideas/suggestions regarding formatting:
- [x] Should we link more to the definitions?

TODO
- [x] Add link to nodes, DMT etc. after #24 