### PR TITLE
Message layer encoding added.

### DIFF
--- a/control_protocol.md
+++ b/control_protocol.md
@@ -318,6 +318,22 @@ For the format of the Messages, see {ref}`control_protocol.md#message-layer`.
 
 ## Message layer
 
+The message layer contains the actual information exchanged between Components.
+As LECO is about controlling experiments, the message layer has to transmit commands, that is calling procedures remotely.
+
+We use the [JSON-RPC](https://www.jsonrpc.org/specification) standard to encode these remote procedure calls (RPC) and the responses.
+We further use the [OpenRPC](https://open-rpc.org/) standard to describe the possibly callable methods of a Component.
+
+Therefore, a Component MUST execute remote procedures according to JSON-RPC and return an appropriate response.
+A Component MUST also offer a list of all possibly callable methods in accordance with OpenRPC.
+
+For such a RPC message, the first content frame MUST consist in a JSON-RPC compatible content, for example a single request object or a batch.
+
+
+:::{note}
+TODO allow several frames for consecutive execution?
+:::
+
 
 ### Messages for Transport Layer
 
@@ -329,8 +345,6 @@ For the format of the Messages, see {ref}`control_protocol.md#message-layer`.
 - CO_SIGNIN
 - CO_SIGNOUT
 
-
-
 :::{note}
-TODO
+TODO How to make these messages work? Define them directly in the transport layer?
 :::

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -321,18 +321,14 @@ For the format of the Messages, see {ref}`control_protocol.md#message-layer`.
 The message layer contains the actual information exchanged between Components.
 As LECO is about controlling experiments, the message layer has to transmit commands, that is calling procedures remotely.
 
-We use the [JSON-RPC](https://www.jsonrpc.org/specification) standard to encode these remote procedure calls (RPC) and the responses.
+We use the [JSON-RPC](https://www.jsonrpc.org/specification) standard to encode these *remote procedure calls* (RPC) and the responses.
 We further use the [OpenRPC](https://open-rpc.org/) standard to describe the possibly callable methods of a Component.
 
 Therefore, a Component MUST execute remote procedures according to JSON-RPC and return an appropriate response.
 A Component MUST also offer a list of all possibly callable methods in accordance with OpenRPC.
 
-For such a RPC message, the first content frame MUST consist in a JSON-RPC compatible content, for example a single request object or a batch.
+For such a RPC message, the first content frame MUST consist in a JSON-RPC compatible content, for example a single request object or a batch of request objects.
 
-
-:::{note}
-TODO allow several frames for consecutive execution?
-:::
 
 
 ### Messages for Transport Layer

--- a/requirements/leco-protocol.yml
+++ b/requirements/leco-protocol.yml
@@ -1,0 +1,6 @@
+dependencies:
+# Development dependencies below
+  - sphinx=4.3.1
+  - sphinx_rtd_theme=1.0.0
+  - myst-parser
+  - sphinxcontrib-mermaid


### PR DESCRIPTION
Adds a few lines about the message layer encoding, see #43 

Open questions:
- [x] How to encode "transport layer messages" (sign in...?)
- [x] should we allow several frames with RPC requests?

Reasoning for several frames with RPC requests:
According to JSON-RPC, all requests in a batch may be executed simultaneously and in any order.
Therefore, if you want to measure the results of an action, you have to send to JSON-RPC requests, one after the other.
If we allow more than one frame with those request objects (or batches thereof), we could stipulate, that the frames have to be executed in order.

It's an abstract idea, but maybe you deem it useful.