### PR TITLE
remove possibility for multiple content frames

### DIFF
--- a/control_protocol.md
+++ b/control_protocol.md
@@ -58,7 +58,7 @@ A message consists of 4 or more frames.
 2. The receiver Full name or Component name, as appropriate.
 3. The sender Full name.
 4. A content header (abbreviated with "H" in examples).
-5. Message content: The optional payload, which can be 0 or more frames.
+5. Message content: The optional payload, which can be 0 or 1 frame.
 
 
 #### Directory


### PR DESCRIPTION
In #54 we concluded that we want, for the first version of the protocol, to restrict messages to a single json-rpc frame. This now corrects an additional place where multiple frames were mentioned. 