### PR TITLE
Improve Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This initiative was born out of a desire of PyMeasure developers, contributors a
 LECO is meant to be a specification for a (programming-language-independent) protocol to enable users to run experiments with a number of hardware devices, including logging, data storage, plotting, and GUI.
 
 [PyMeasure](https://pymeasure.readthedocs.io) is an obvious candidate for working with this protocol, and as such will influence the design somewhat, but we will take pains to make sure the protocol will be agnostic to the actual interface package (or language) used.
-The authors draw on their varied experience setting up such solutions in a homebrew fashion.
+The authors draw on their varied experience setting up such solutions in a number of research laboratories.
 
 
 ## Overview
@@ -27,8 +27,8 @@ There exist two different communication protocols in LECO.
 
 A LECO network needs at least one _Coordinator_ (server), which routes the messages among the connected _Components_.
 
-Each _Component_ has a name unique in the network.
-This name consists in the name of the _Coordinator_ they are connected to and their own name.
+Each _Component_ has a name unique in the network, by which it may be addressed.
+This name consists of the name of the _Coordinator_ (_Namespace_) they are connected to and their own name.
 For example `N1.component1` is the full name of `component1` connected to the _Coordinator_ of the _Namespace_ `N1`.
 That _Coordinator_ itself is called `N1.COORDINATOR`, as _Coordinators_ are always called `COORDINATOR`.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,37 @@
 # LECO - Laboratory Experiment Control Protocol
 Design notes for a generic communication protocol to control experiments and measurement hardware.
 
+
+## Introduction
+
 This initiative was born out of a desire of PyMeasure developers, contributors and users to achieve improved and more flexible experiment orchestration/execution, and to achieve (better) interoperation with other instrument control libraries.
 
 LECO is meant to be a specification for a (programming-language-independent) protocol to enable users to run experiments with a number of hardware devices, including logging, data storage, plotting, and GUI.
-Communication will happen via messages (using [zeromq](https://zeromq.org/)) between participants in a single application or distributed over the network.
 
 [PyMeasure](https://pymeasure.readthedocs.io) is an obvious candidate for working with this protocol, and as such will influence the design somewhat, but we will take pains to make sure the protocol will be agnostic to the actual interface package (or language) used.
 The authors draw on their varied experience setting up such solutions in a homebrew fashion.
 
+
+## Overview
+
+This is an overview over the LECO protocol.
 See the [documentation](https://leco-laboratory-experiment-control-protocol.readthedocs.io/en/latest/) for a more exhaustive description of the protocol and its elements.
+
+Communication happens via messages (using [zeromq](https://zeromq.org/)) between participants (called _Component_) in a single application or distributed over the network.
+
+There exist two different communication protocols in LECO.
+1. The _control protocol_ allows to exchange messages between any two _Components_ in a LECO network, which is useful for controlling devices.
+   The default implementation uses _remote procedure calls_ according to [JSON-RPC](https://www.jsonrpc.org/specification).
+2. The _data protocol_ is a broadcasting protocol to send information to all those, who want to receive it, which is useful for regular measurement data or for log entries.
+   It allows to implement event notifications.
+
+A LECO network needs at least one _Coordinator_ (server), which routes the messages among the connected _Components_.
+
+Each _Component_ has a name unique in the network.
+This name consists in the name of the _Coordinator_ they are connected to and their own name.
+For example `N1.component1` is the full name of `component1` connected to the _Coordinator_ of the _Namespace_ `N1`.
+That _Coordinator_ itself is called `N1.COORDINATOR`, as _Coordinators_ are always called `COORDINATOR`.
+
 
 ## Implementations
 

--- a/appendix.md
+++ b/appendix.md
@@ -22,6 +22,7 @@ That way, an answer to that message can be returned to this same peer, and not a
 Consequently, in order to send such an answer, the identity has to be prepended to the frames to send: Calling the ROUTER's send command with `IA|Reply A`, the socket will send `Reply A` to the peer, whose identity is `IA`, in this case that is `CA`.
 
 The following diagram shows this example communication with two Components:
+:::{mermaid}
 sequenceDiagram
     participant Code as Message handling
     participant ROUTER as ROUTER socket


### PR DESCRIPTION
Add a small description of the content to the readme.

Closes #67 

Additional parts:
- ~~Replaces colon fences of mermaid diagrams with back ticks. That way they are already rendered correctly on github.~~ Does not work, as sphinx expects curly braces and github does not.