### PR TITLE
Generate pyleco state documentation

### DIFF
--- a/components.md
+++ b/components.md
@@ -131,6 +131,12 @@ Multiple Control Coordinator instances MAY be necessary for large deployments, b
 A Data Coordinator is responsible for receiving and publishing data channel messages.
 It uses a publish-subscribe connection pattern.
 
+For single-Node deployments, a Data Coordinator MAY consist of a single proxy server (XSUB/XPUB).
+
+For multi-Node deployments, a Data Coordinator SHOULD use the [Gatherer/Distributor architecture](data_protocol.md#multi-node-configuration) to enable loop-free cross-Node data distribution.
+
+A Data Coordinator MAY participate in the control protocol (signing in as a Component) to allow the local Control Coordinator to dynamically configure remote Gatherer connections, see [Data Coordinator methods](methods.md#data-coordinator).
+
 ### Logging Coordinator
 
 A Logging Coordinator is responsible for receiving and publishing logging channel messages.

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -13,6 +13,7 @@ The transport layer ensures that a message arrives at its destination.
 
 Each [Coordinator](components.md#coordinator) SHALL offer one [ROUTER](appendix.md#router-sockets) socket, bound to an address.
 The address consists of a host (this can be the host name, an IP address of the device, or "\*" for all IP addresses of the device) and a port number, for example `*:12345` for all IP addresses at the port `12345`.
+The default port number is 12300.
 
 [Components](components.md#components) SHALL have one DEALER socket connecting to one Coordinator's ROUTER socket.
 

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -304,10 +304,14 @@ sequenceDiagram
 Note that the DEALER socket responds with the local Directory and Coordinator addresses to the received Acknowledgment.
 :::
 
+If a not signed in Coordinator tries to sign out from a second one, the latter one MUST ignore that message.
+If a Coordinator tries to sign out, but the message arrives via a different identity, the sign-out MUST be rejected.
+
 ##### Coordinator updates
 
 Each Coordinator SHALL keep an up-to-date global [Directory](control_protocol.md#directory) with the Full names of all Components in the Network.
 For this, whenever a Component signs in to or out from its Coordinator, the Coordinator SHALL notify all the other Coordinators regarding this event.
+For that, the Coordinators SHALL send the other ones the full directory, i.e. all Components and Coordinators connected to the Coordinator.
 The other Coordinators SHALL update their global Directory according to this message (add or remove an entry).
 
 :::{note}

--- a/data_protocol.md
+++ b/data_protocol.md
@@ -8,12 +8,12 @@ The transport layer ensures that a message arrives at its destination.
 
 ### Socket configuration
 
-A `proxy server` is the transmitting station, it shall offer an XSUBSCRIBER and an XPUBLISHER socket.
-The two sockets shall be connected, e.g. via the `zmq.proxy_server` method.
-Each of both sockets shall be bound to its own address.
+A `proxy server` is the transmitting station, it SHALL offer an XSUBSCRIBER and an XPUBLISHER socket.
+The two sockets SHALL be connected, e.g. via the `zmq.proxy_server` method.
+Each of both sockets SHALL be bound to its own address.
 
 A `Publisher` is a Component, which sends data messages via the data protocol.
-It shall have a PUBLISHER socket connecting to the proxy server's XSUBSCRIBER socket.
+It SHALL have a PUBLISHER socket connecting to the proxy server's XSUBSCRIBER socket.
 
 A `Subscriber` is a Component, which wants to reveice data messages via the data protocol.
 It SHALL have a SUBSCRIBER socket connecting to the proxy server's XPUBLISHER socket.

--- a/data_protocol.md
+++ b/data_protocol.md
@@ -1,0 +1,61 @@
+# Data protocol
+
+The data protocol transmits messages from `publishers` to `subscribers` via a `proxy server` in a broadcasting fashion.
+
+## Transport layer
+
+The transport layer ensures that a message arrives at its destination.
+
+### Socket configuration
+
+A `proxy server` is the transmitting station, it shall offer an XSUBSCRIBER and an XPUBLISHER socket.
+The two sockets shall be connected, e.g. via the `zmq.proxy_server` method.
+Each of both sockets shall be bound to its own address.
+
+A `Publisher` is a Component, which sends data messages via the data protocol.
+It shall have a PUBLISHER socket connecting to the proxy server's XSUBSCRIBER socket.
+
+A `Subscriber` is a Component, which wants to reveice data messages via the data protocol.
+It SHALL have a SUBSCRIBER socket connecting to the proxy server's XPUBLISHER socket.
+It SHOULD subscribe to the [Topics](data_protocol.md#topic) it wants to receive.
+
+:::{note}
+Subscribing to a topic in zmq means to subscribe to all topics which **start** with the given topic name!
+:::
+
+#### Recommended configuration
+
+It is recommended to have a single program with two proxy servers.
+The first one transfers any data and binds its XSUBSCRIBER to port number 11100 and binds its XPUBLISHER to 11099.
+The second one transfers log entries and binds to 11098 and 11097, respectively.
+
+
+## Message format
+
+A Data Protocol Message consists of 3 or more ZMQ frames ([#62](https://github.com/pymeasure/leco-protocol/issues/62)):
+
+1. [Topic](data_protocol.md#topic)
+2. [Header](data_protocol.md#header)
+3. One or more data frames, the first one is the [Content](data_protocol.md#content)
+
+### Topic
+
+The topic is the Full name of the sending Component, encoded as printable ASCII bytes (no length prefix, no null terminator; the ZMQ frame boundary delimits the string), as defined in the [naming scheme](control_protocol.md#naming-scheme). ([#60](https://github.com/pymeasure/leco-protocol/issues/60))
+
+Subscribers can subscribe to all messages from a specific Component by subscribing to its Full name. Due to ZMQ's prefix-matching subscription behavior, subscribing to a Namespace prefix (e.g. `N1.`) will match all messages from all Components in that Namespace.
+
+### Header
+
+Similar to the {ref}`control protocol header <control_protocol.md#message-composition>`, the header consists in
+1. UUIDv7
+2. a one byte `message_type` (`0` not defined, `1` JSON, `>127` user defined)
+
+### Content
+
+#### Log message content
+
+For log messages, the content is a JSON encoded list of:
+- `record.asctime`: Timestamp formatted as `'%Y-%m-%d %H:%M:%S'`
+- `record.levelname`: Logger level name
+- `record.name`: Logger name
+- `record.text` (including traceback)

--- a/data_protocol.md
+++ b/data_protocol.md
@@ -29,6 +29,60 @@ It is recommended to have a single program with two proxy servers.
 The first one transfers any data and binds its XSUBSCRIBER to port number 11100 and binds its XPUBLISHER to 11099.
 The second one transfers log entries and binds to 11098 and 11097, respectively.
 
+#### Multi-node configuration
+
+For deployments spanning multiple [Nodes](network-structure.md#node), a Data Coordinator SHOULD use a Gatherer/Distributor architecture to enable loop-free cross-node data distribution.
+
+A Data Coordinator following this architecture contains two internally coupled proxy servers:
+
+**Gatherer**
+: A proxy server that collects messages from local publishers.
+Its XSUB socket is bound to the standard port (e.g. 11100 for data) for local publishers to connect to.
+Its XPUB socket is bound to a separate port (e.g. 11101 for data) for remote Distributors to connect to.
+
+**Distributor**
+: A proxy server that distributes messages to local subscribers.
+Its XSUB socket connects to the local Gatherer's XPUB socket and to remote Gatherers' XPUB sockets.
+Its XPUB socket is bound to the standard subscriber port (e.g. 11099 for data) for local subscribers to connect to.
+
+Messages flow strictly from publishers through the Gatherer to the Distributor and then to subscribers.
+Since there is no path from a Distributor back into any Gatherer, the topology is structurally loop-free without requiring topic-based filtering.
+
+```mermaid
+flowchart LR
+    subgraph Node1
+        P1["Publisher 1"]
+        P2["Publisher 2"]
+        subgraph X1[Data Coordinator N1]
+            G1["Gatherer N1"]
+            D1["Distributor N1"]
+        end
+        S1["Subscriber 1"]
+        S2["Subscriber 2"]
+        P1 -->|"PUB → XSUB"| G1
+        P2 -->|"PUB → XSUB"| G1
+        G1 -->|"XPUB → XSUB"| D1
+        D1 -->|"XPUB → SUB"| S1
+        D1 -->|"XPUB → SUB"| S2
+    end
+    subgraph Node2
+        P3["Publisher 3"]
+        subgraph X2[Data Coordinator N2]
+            G2["Gatherer N2"]
+            D2["Distributor N2"]
+        end
+        S3["Subscriber 3"]
+        P3 -->|"PUB → XSUB"| G2
+        G2 -->|"XPUB → XSUB"| D2
+        D2 -->|"XPUB → SUB"| S3
+    end
+    G1 -.->|"XPUB → XSUB (remote)"| D2
+    G2 -.->|"XPUB → XSUB (remote)"| D1
+```
+
+Each Distributor subscribes to both the local Gatherer and all remote Gatherers, ensuring that local subscribers receive messages from all Nodes in the Network.
+
+It is recommended that a Data Coordinator participating in the control protocol exposes methods for the local [Control Coordinator](components.md#control-coordinator) to dynamically configure remote Gatherer connections during [coordinator_sign_in](control_protocol.md#coordinator-sign-in), see [Data Coordinator methods](methods.md#data-coordinator).
 
 ## Message format
 

--- a/data_protocol.md
+++ b/data_protocol.md
@@ -100,16 +100,51 @@ Subscribers can subscribe to all messages from a specific Component by subscribi
 
 ### Header
 
-Similar to the {ref}`control protocol header <control_protocol.md#message-composition>`, the header consists in
-1. UUIDv7
-2. a one byte `message_type` (`0` not defined, `1` JSON, `>127` user defined)
+A single ZMQ frame of exactly 17 bytes, laid out as follows:
+
+| Offset | Length | Field             | Encoding                                       |
+|--------|--------|-------------------|------------------------------------------------|
+| 0      | 16     | `conversation_id` | UUIDv7, 16 bytes in network (big-endian) order |
+| 16     | 1      | `message_type`    | Unsigned 8-bit integer                         |
+
+Defined `message_type` values:
+
+| Value | Meaning      |
+|-------|--------------|
+| 0     | Not defined  |
+| 1     | JSON encoded |
+
+Values 2–127 are reserved for future protocol use. Values 128–255 are available for implementation-defined use.
 
 ### Content
 
+The first content frame carries the payload. When `message_type` is `1`, the first content frame MUST be a UTF-8 encoded JSON value. Additional content frames beyond the first are permitted for implementation-defined use but MUST be ignored by receivers that do not understand them.
+
 #### Log message content
 
-For log messages, the content is a JSON encoded list of:
+For log messages (`message_type` = `1`), the content is a JSON encoded list of:
 - `record.asctime`: Timestamp formatted as `'%Y-%m-%d %H:%M:%S'`
 - `record.levelname`: Logger level name
 - `record.name`: Logger name
 - `record.text` (including traceback)
+
+### Relationship to the control protocol
+
+Publishers and Subscribers are Components and MAY also participate in the control protocol by connecting to their Node's Control Coordinator and signing in. Doing so allows them to be addressed by Full name and enables remote management (e.g. configuring subscriptions, adjusting log levels, or shutting down).
+
+A Publisher MUST use the same Full name as the topic that it uses when signed into the control protocol, to allow Subscribers to discover and address it.
+
+### Wire format test vector
+
+**Test vector: Log message from `N1.Recorder`**
+
+Assumptions: conversation_id = `0190a2b3c4d5e6f7a8b9c0d1e2f3a4b5`, message_type = `0x01` (JSON).
+
+```
+4E312E5265636F72646572 | 0190a2b3c4d5e6f7a8b9c0d1e2f3a4b5 01 | 5B22323032352D30342D32342031323A30303A3030222C2022494E464F222C20227265636F72646572222C20224D6561737572656D656E742073746172746564225D
+```
+
+Frame breakdown:
+- Frame 1: topic `N1.Recorder` (ASCII)
+- Frame 2 (17 bytes): header (UUIDv7 + message_type)
+- Frame 3: JSON content `["2025-04-24 12:00:00","INFO","recorder","Measurement started"]`

--- a/glossary.md
+++ b/glossary.md
@@ -24,6 +24,9 @@ Device
 Director
     A Component which takes part in orchestrating a (i.e. LECO-controlled) measurement setup, see [Director](components.md#director).
 
+Distributor
+    The second proxy server in a multi-Node Data Coordinator, which distributes messages to local subscribers, receiving from both the local and remote Gatherers. See [Data Protocol](data_protocol.md#multi-node-configuration).
+
 Directory
     Each Coordinator maintains a local Directory with all the Components connected to it (i.e. other Coordinators and the Components of its own Node), and a global Directory with all Components in the whole Network, see [Directory](control_protocol.md#directory).
 
@@ -33,6 +36,9 @@ Driver
 Full name
     The name of a Component unique for the whole setup.
     It consists of the namespace and component-name, see [Naming scheme](control_protocol.md#naming-scheme).
+
+Gatherer
+    The first proxy server in a multi-Node Data Coordinator, which collects messages from local publishers. See [Data Protocol](data_protocol.md#multi-node-configuration).
 
 LECO
     The **L**aboratory **E**xperiment **CO**ntrol protocol framework.

--- a/index.rst
+++ b/index.rst
@@ -16,6 +16,7 @@
    messages
    network-structure
    control_protocol
+   data_protocol
    glossary
    Hello_world
    appendix

--- a/messages.md
+++ b/messages.md
@@ -7,3 +7,11 @@ A Message consists of a Header with some metadata (e.g. routing information need
 :::{admonition} Note
 A heartbeat message might not need a payload.
 :::
+
+## Common elements
+
+All LECO messages share the following conventions regardless of category:
+
+- **Frames**: All messages are composed of one or more ZMQ frames (byte sequences), with frame boundaries serving as delimiters.
+- **String encoding**: Name and topic fields are restricted to printable ASCII bytes (0x20–0x7E, excluding 0x2E `.`) and encoded without length prefixes or null terminators; ZMQ frame boundaries delimit the data. JSON content frames are UTF-8 encoded.
+- **Integer encoding**: Multi-byte integers in binary headers use big-endian (network) byte order.

--- a/methods.md
+++ b/methods.md
@@ -60,3 +60,13 @@ An [Actor](methods.md#actor) which supports locking resources MUST offer the fol
 :::
 
 Accessing a locked resource (the whole Component or parts of it) or trying to unlock one, locked by another Component, will raise appropriate [Errors](control_protocol.md#errors).
+
+## Data Coordinator
+
+A [Component](methods.md#component) acting as a [Data Coordinator](components.md#data-coordinator), which participates in the control protocol to allow dynamic configuration of remote [Gatherer](glossary.md#gatherer) connections for multi-Node data distribution.
+It MAY offer the following methods.
+
+:::{leco-json-viewer}
+:expand:
+:file: schemas/data_coordinator.json
+:::

--- a/network-structure.md
+++ b/network-structure.md
@@ -50,6 +50,31 @@ flowchart LR
 
 Control Coordinator to Control Coordinator communication always uses DMT.
 
+### Data Network Topology
+
+For data distribution across multiple Nodes, each Node's [Data Coordinator](components.md#data-coordinator) uses a [Gatherer/Distributor architecture](data_protocol.md#multi-node-configuration).
+Each Node's Distributor connects to the Gatherers of all other Nodes in the Network, ensuring that subscribers in any Node receive data published in any other Node.
+
+In this graph, data published by `Publisher1` would pass through `Gatherer N1` to `Distributor N1` (for local subscribers) and also to `Distributor N2` via the cross-Node connection (for remote subscribers).
+
+```mermaid
+flowchart LR
+    subgraph Node1
+        P1["Publisher 1"] -->|"PUB → XSUB"| G1["Gatherer N1"]
+        G1 -->|"XPUB → XSUB"| D1["Distributor N1"]
+        D1 -->|"XPUB → SUB"| S1["Subscriber 1"]
+    end
+    subgraph Node2
+        P2["Publisher 2"] -->|"PUB → XSUB"| G2["Gatherer N2"]
+        G2 -->|"XPUB → XSUB"| D2["Distributor N2"]
+        D2 -->|"XPUB → SUB"| S2["Subscriber 2"]
+    end
+    G1 -.->|"XPUB → XSUB"| D2
+    G2 -.->|"XPUB → XSUB"| D1
+```
+
+Cross-Node Gatherer connections can be configured statically or dynamically via the control protocol (see [Data Coordinator methods](methods.md#data-coordinator)).
+
 ## Message Transport Mode (LMT/DMT)
 
 The Node-local Message Layer can have a local or distributed mode.

--- a/schemas/data_coordinator.json
+++ b/schemas/data_coordinator.json
@@ -1,0 +1,142 @@
+{
+    "openrpc": "1.2.6",
+    "info": {
+        "title": "Data Coordinator",
+        "summary": "Methods for a Data Coordinator participating in the control protocol to manage remote Gatherer connections.",
+        "version": "0.1.0"
+    },
+    "methods": [
+        {
+            "name": "connect_to_gatherer",
+            "summary": "Connect the local Distributor to a remote Gatherer's XPUB socket.",
+            "params": [
+                {
+                    "name": "address",
+                    "summary": "Address of the remote Gatherer's XPUB socket (e.g. 'host:11101').",
+                    "schema": {
+                        "type": "string"
+                    },
+                    "required": true
+                }
+            ],
+            "result": {
+                "name": "result",
+                "schema": {
+                    "type": "null"
+                },
+                "required": true
+            },
+            "errors": [
+                {
+                    "code": -32110,
+                    "message": "Already connected to this Gatherer.",
+                    "data": "Address of the already connected Gatherer."
+                }
+            ]
+        },
+        {
+            "name": "disconnect_from_gatherer",
+            "summary": "Disconnect the local Distributor from a remote Gatherer's XPUB socket.",
+            "params": [
+                {
+                    "name": "address",
+                    "summary": "Address of the remote Gatherer's XPUB socket to disconnect from.",
+                    "schema": {
+                        "type": "string"
+                    },
+                    "required": true
+                }
+            ],
+            "result": {
+                "name": "result",
+                "schema": {
+                    "type": "null"
+                },
+                "required": true
+            },
+            "errors": [
+                {
+                    "code": -32111,
+                    "message": "Not connected to this Gatherer.",
+                    "data": "Address of the Gatherer."
+                }
+            ]
+        },
+        {
+            "name": "list_gatherers",
+            "summary": "List the addresses of remote Gatherers the local Distributor is connected to.",
+            "params": [],
+            "result": {
+                "name": "result",
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "required": true
+            },
+            "examples": [
+                {
+                    "name": "List gatherers example",
+                    "params": [],
+                    "result": {
+                        "name": "result",
+                        "value": [
+                            "host_of_node2:11101",
+                            "host_of_node3:11101"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "name": "send_data_addresses",
+            "summary": "Send the bound socket addresses of this Data Coordinator's Gatherer and Distributor.",
+            "description": "Returns the addresses that local publishers, local subscribers, and remote Distributors need to connect to. The Distributor's XSUB address is not included as it is an outbound connection.",
+            "params": [],
+            "result": {
+                "name": "result",
+                "schema": {
+                    "$ref": "#/components/data_addresses"
+                },
+                "required": true
+            },
+            "examples": [
+                {
+                    "name": "Data addresses example",
+                    "params": [],
+                    "result": {
+                        "name": "result",
+                        "value": {
+                            "gatherer_xsub": "*:11100",
+                            "gatherer_xpub": "*:11101",
+                            "distributor_xpub": "*:11099"
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "components": {
+        "data_addresses": {
+            "type": "object",
+            "summary": "Bound socket addresses of a Data Coordinator.",
+            "properties": {
+                "gatherer_xsub": {
+                    "type": "string",
+                    "summary": "Address of the Gatherer's XSUB socket for local publishers to connect to."
+                },
+                "gatherer_xpub": {
+                    "type": "string",
+                    "summary": "Address of the Gatherer's XPUB socket for remote Distributors to connect to."
+                },
+                "distributor_xpub": {
+                    "type": "string",
+                    "summary": "Address of the Distributor's XPUB socket for local subscribers to connect to."
+                }
+            },
+            "required": ["gatherer_xsub", "gatherer_xpub", "distributor_xpub"]
+        }
+    }
+}


### PR DESCRIPTION
This PR is made to render the documentation according to the current PyLECO state:

https://leco-laboratory-experiment-control-protocol--69.org.readthedocs.build/en/69/