### PR TITLE
Use mermaid fence blocks instead of colon-fence directives

### DIFF
--- a/Hello_world.md
+++ b/Hello_world.md
@@ -25,7 +25,7 @@ Note, that you have to use a colon fence in a markdown file instead of the norma
 
 And finally, here's a cool mermaid diagram!
 
-:::{mermaid}
+```mermaid
 sequenceDiagram
   participant Alice
   participant Bob
@@ -37,7 +37,7 @@ sequenceDiagram
   John-->Alice: Great!
   John->Bob: How about you?
   Bob-->John: Jolly good!
-:::
+```
 
 
 

--- a/appendix.md
+++ b/appendix.md
@@ -20,7 +20,7 @@ That way, an answer to that message can be returned to this same peer, and not a
 Consequently, in order to send such an answer, the identity has to be prepended to the frames to send: Calling the ROUTER's send command with `IA|Reply A`, the socket will send `Reply A` to the peer, whose identity is `IA`, in this case that is `CA`.
 
 The following diagram shows this example communication with two Components:
-:::{mermaid}
+```mermaid
 sequenceDiagram
     participant Code as Message handling
     participant ROUTER as ROUTER socket
@@ -33,4 +33,4 @@ sequenceDiagram
     ROUTER ->> Code: "IB|Request B"
     Code ->> ROUTER: "IB|Reply B"
     ROUTER ->> CB: "Reply B"
-:::
+```

--- a/components.md
+++ b/components.md
@@ -85,7 +85,7 @@ It MAY act regularly of its own accord.
 The Processor would send commands to an Actor, instructing it to `set`/`get`/`call` a given Parameter/Action by name, with a value if appropriate, and receive replies.
 
 This could look for example like this:
-:::{mermaid}
+```mermaid
 sequenceDiagram
     par
         Processor1->>Actor42: GET temp_K
@@ -101,7 +101,7 @@ sequenceDiagram
     Note over Processor1: computes average temperature, converts to degC
     Note over Processor1: stores/caches value maybe
     Processor1->>Observer1: "Average oven temperature" 14.47 degC
-:::
+```
 
 ## Coordinator
 

--- a/conf.py
+++ b/conf.py
@@ -30,7 +30,9 @@ extensions = [
 
 myst_enable_extensions = [
     "colon_fence",
+    "attrs_block",
 ]
+myst_fence_as_directive = ["mermaid"]
 myst_heading_anchors = 5
 
 templates_path = ["_templates"]

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -109,7 +109,7 @@ After connecting to a Coordinator (`Co1`), a Component (`CA`) SHALL send a `sign
 
 **Unsigned Components:** If a Component sends a message without having signed in, the Coordinator SHALL refuse message handling and return an error.
 
-:::{mermaid}
+```mermaid
 sequenceDiagram
     Note over CA,N1: Name "CA" is still free
     participant N1 as N1.COORDINATOR
@@ -128,7 +128,7 @@ sequenceDiagram
     Note right of N1: Does not know CA
     N1 ->> CA: V|CA|N1.COORDINATOR|H|ERROR: Component not signed in yet!
     Note left of CA: Must send a sign_in message<br> before further messaging.
-:::
+```
 
 ##### Heartbeat
 
@@ -149,7 +149,7 @@ A Component SHOULD send a `sign_out` message (see {ref}`methods.md#coordinator`)
 The Coordinator SHALL acknowledge the sign-out with a `result` message and remove the Component name from its local {ref}`control_protocol.md#directory`.
 It SHALL also notify the other Coordinators in the network that this Component signed out, see {ref}`control_protocol.md#coordinator-coordination`.
 
-:::{mermaid}
+```mermaid
 sequenceDiagram
     CA ->> N1: V|COORDINATOR|N1.CA|H|sign_out
     participant N1 as N1.COORDINATOR
@@ -157,7 +157,7 @@ sequenceDiagram
     Note right of N1: Removes "CA" with identity "IA"<br> from local Directory
     Note right of N1: Notifies other Coordinators about sign-out of "CA"
     Note left of CA: Shall not send any message anymore except sign_in
-:::
+```
 
 #### Communication with other Components
 
@@ -165,7 +165,7 @@ The following two examples show how a message is transferred between two compone
 
 Coordinators SHALL route the message to the corresponding Coordinator or connected Component.
 
-:::{mermaid}
+```mermaid
 sequenceDiagram
     alt Full name
         CA ->> N1: V|N1.CB|N1.CA|H| Give me property A.
@@ -177,9 +177,9 @@ sequenceDiagram
     Note left of CB: Reads property A
     CB ->> N1: V|N1.CA|N1.CB|H| Property A has value 5.
     N1 ->> CA: V|N1.CA|N1.CB|H| Property A has value 5.
-:::
+```
 
-:::{mermaid}
+```mermaid
 sequenceDiagram
     CA ->> N1: V|N2.CB|N1.CA|H| Give me property A.
     participant N1 as N1.COORDINATOR
@@ -192,7 +192,7 @@ sequenceDiagram
     Note over N1,N2: N2 DEALER socket sends to N1 ROUTER
     N2 ->> N1: V|N1.CA|N2.CB|H| Property A has value 5.
     N1 ->> CA: V|N1.CA|N2.CB|H| Property A has value 5.
-:::
+```
 
 Prerequisites of Communication between two Components are:
 
@@ -208,7 +208,7 @@ Bold arrows indicate message flow, thin lines indicate decision flow.
 Thin, dotted lines indicate decision flow in case of errors.
 Placeholder values are written in lowercase, while actually known values begin with an uppercase letter.
 
-:::{mermaid}
+```mermaid
 flowchart TB
     C1([N1.CA DEALER]) == "V|nR.recipient|nS.CA|H|Content" ==> R0
     C0([nS.COORDINATOR DEALER]) == "V|nR.recipient|nS.CA|H|Content" ==> R0
@@ -243,7 +243,7 @@ flowchart TB
     subgraph "Co1 DEALER socket <br>to N2.COORDINATOR"
         R2
     end
-:::
+```
 
 #### Coordinator coordination
 
@@ -262,7 +262,7 @@ Similarly to Component sign-in, the Coordinator SHALL refuse a sign-in request w
 
 These are the sign-in/sign-out sequences between Coordinators, where `address` is for example the host name and port number of the Coordinator's ROUTER socket.
 
-:::{mermaid}
+```mermaid
 sequenceDiagram
     participant r1 as ROUTER
     participant d1 as DEALER
@@ -298,7 +298,7 @@ sequenceDiagram
     d2->>-r1: coordinator_sign_out
     Note right of r1: removes N2 identity
     deactivate d1
-:::
+```
 
 :::{note}
 Note that the DEALER socket responds with the local Directory and Coordinator addresses to the received Acknowledgment.

--- a/control_protocol.md
+++ b/control_protocol.md
@@ -1,7 +1,7 @@
 # Control protocol
 
-The control protocol transmits messages via its {ref}`control_protocol.md#transport-layer` from one Component to another.
-The {ref}`control_protocol.md#message-layer` is the common language to understand commands, thus creating a remote procedure call.
+The control protocol transmits messages via its [Transport layer](control_protocol.md#transport-layer) from one Component to another.
+The [Message layer](control_protocol.md#message-layer) is the common language to understand commands, thus creating a remote procedure call.
 
 ## Transport layer
 
@@ -11,10 +11,10 @@ The transport layer ensures that a message arrives at its destination.
 
 #### Socket Configuration
 
-Each {ref}`Coordinator <components.md#coordinator>` SHALL offer one {ref}`ROUTER <appendix.md#router-sockets>` socket, bound to an address.
+Each [Coordinator](components.md#coordinator) SHALL offer one [ROUTER](appendix.md#router-sockets) socket, bound to an address.
 The address consists of a host (this can be the host name, an IP address of the device, or "\*" for all IP addresses of the device) and a port number, for example `*:12345` for all IP addresses at the port `12345`.
 
-{ref}`Components <components.md#components>` SHALL have one DEALER socket connecting to one Coordinator's ROUTER socket.
+[Components](components.md#components) SHALL have one DEALER socket connecting to one Coordinator's ROUTER socket.
 
 Coordinators SHALL have one DEALER socket per other Coordinator in the Network.
 This DEALER socket SHALL connect to the other Coordinator's ROUTER socket.
@@ -24,12 +24,12 @@ While the number of DEALER sockets thus required scales badly with the number of
 :::
 
 Communicating with a Coordinator, messages MUST be sent to a Coordinator's ROUTER socket.
-Only for acknowledging a {ref}`control_protocol.md#coordinator-sign-in`, a Coordinator MAY send a response via its DEALER socket (i.e. the reply may arrive from the DEALER socket the requesting Coordinator connected to, rather than via the ROUTER socket).
+Only for acknowledging a [Coordinator sign-in](control_protocol.md#coordinator-sign-in), a Coordinator MAY send a response via its DEALER socket (i.e. the reply may arrive from the DEALER socket the requesting Coordinator connected to, rather than via the ROUTER socket).
 
 #### Naming scheme
 
 Each Component MUST have an individual name, given by the user, the _Component name_.
-Component names MUST be unique in a {ref}`Node <network-structure.md#node>`, i.e. among the Components (except other Coordinators) connected to a single Coordinator.
+Component names MUST be unique in a [Node](network-structure.md#node), i.e. among the Components (except other Coordinators) connected to a single Coordinator.
 A Coordinator itself MUST have the Component name `COORDINATOR`.
 
 Similarly, every Node MUST have a name, the _Namespace_.
@@ -51,7 +51,7 @@ The sender of a message MUST be specified by Full name, except for the `sign_in`
 A message consists of 4 or more ZMQ frames.
 
 1. **Protocol version** (abbreviated with "V" in examples): a single byte, for example `0` (`0x00`).
-2. **Receiver**: the receiver Full name or Component name as appropriate, encoded as printable ASCII bytes (no length prefix, no null terminator; the ZMQ frame boundary delimits the string), as defined in the {ref}`naming scheme <control_protocol.md#naming-scheme>`.
+2. **Receiver**: the receiver Full name or Component name as appropriate, encoded as printable ASCII bytes (no length prefix, no null terminator; the ZMQ frame boundary delimits the string), as defined in the [naming scheme](control_protocol.md#naming-scheme).
 3. **Sender**: the sender Full name, encoded as printable ASCII bytes (same framing as receiver).
 4. **Content header** (abbreviated with "H" in examples): a single ZMQ frame of exactly 20 bytes, laid out as follows:
 
@@ -85,7 +85,7 @@ Additionally, they SHALL maintain a _global Directory_, which is a Coordinator's
 In the protocol examples, `CA`, `CB`, etc. indicate Component names.
 `N1`, `N2`, etc. indicate Node Namespaces and `Co1`, `Co2` their corresponding Coordinators.
 
-Here the Message content is expressed in plain English and placed in the Content frame, for the exact definition see {ref}`control_protocol.md#message-layer`.
+Here the Message content is expressed in plain English and placed in the Content frame, for the exact definition see [Message layer](control_protocol.md#message-layer).
 
 :::{note}
 TBD: How to show the encoded content in the examples?
@@ -97,12 +97,12 @@ In the exchange of messages, only the messages over the wire are shown, the conn
 
 ##### Signing-in
 
-After connecting to a Coordinator (`Co1`), a Component (`CA`) SHALL send a `sign_in` message (see {ref}`methods.md#coordinator`) indicating its Component name in the sender frame of the envelope.
+After connecting to a Coordinator (`Co1`), a Component (`CA`) SHALL send a `sign_in` message (see [Coordinator](methods.md#coordinator)) indicating its Component name in the sender frame of the envelope.
 
 **Success:** The Coordinator SHALL accept the sign-in with a `result` response (according to [JSON-RPC](https://www.jsonrpc.org/specification)), using its own Full name as the sender in the envelope (e.g. `N1.COORDINATOR`). The Component deduces its Namespace from the Namespace portion of that sender Full name. After a successful handshake:
 
-- The Coordinator SHALL store the Component name in its {ref}`control_protocol.md#directory` and SHALL ensure message delivery to that Component (e.g. by storing the (zmq) connection identity with the local directory).
-- The Coordinator SHALL notify the other Coordinators in the network that this Component signed in, see {ref}`control_protocol.md#coordinator-coordination`.
+- The Coordinator SHALL store the Component name in its [Directory](control_protocol.md#directory) and SHALL ensure message delivery to that Component (e.g. by storing the (zmq) connection identity with the local directory).
+- The Coordinator SHALL notify the other Coordinators in the network that this Component signed in, see [Coordinator coordination](control_protocol.md#coordinator-coordination).
 - The Component SHALL store the Namespace and use it from this moment on, to generate its Full name.
 
 **Error:** If the Component name is already taken, the Coordinator SHALL reply with an ERROR. The Coordinator MAY indicate a suitable, still available variation on the indicated Component name. The Component MAY retry signing in with a different chosen name.
@@ -136,8 +136,8 @@ Heartbeats are used to know whether a communication peer is still online.
 
 Every message received counts as a heartbeat.
 
-A Component SHOULD and a Coordinator SHALL send a `pong` request message (see {ref}`methods.md#actor`) and wait some time before considering a connection dead.
-A Coordinator SHALL follow the {ref}`control_protocol.md#signing-out` for a signed in Component considered dead.
+A Component SHOULD and a Coordinator SHALL send a `pong` request message (see [Actor](methods.md#actor)) and wait some time before considering a connection dead.
+A Coordinator SHALL follow the [Signing out](control_protocol.md#signing-out) for a signed in Component considered dead.
 
 :::{note}
 TBD: Heartbeat details are still to be determined.
@@ -145,9 +145,9 @@ TBD: Heartbeat details are still to be determined.
 
 ##### Signing out
 
-A Component SHOULD send a `sign_out` message (see {ref}`methods.md#coordinator`) to its Coordinator when it stops participating in the Network.
-The Coordinator SHALL acknowledge the sign-out with a `result` message and remove the Component name from its local {ref}`control_protocol.md#directory`.
-It SHALL also notify the other Coordinators in the network that this Component signed out, see {ref}`control_protocol.md#coordinator-coordination`.
+A Component SHOULD send a `sign_out` message (see [Coordinator](methods.md#coordinator)) to its Coordinator when it stops participating in the Network.
+The Coordinator SHALL acknowledge the sign-out with a `result` message and remove the Component name from its local [Directory](control_protocol.md#directory).
+It SHALL also notify the other Coordinators in the network that this Component signed out, see [Coordinator coordination](control_protocol.md#coordinator-coordination).
 
 ```mermaid
 sequenceDiagram
@@ -196,7 +196,7 @@ sequenceDiagram
 
 Prerequisites of Communication between two Components are:
 
-- Both Components are connected to a Coordinator and {ref}`signed in<control_protocol.md#signing-in>`.
+- Both Components are connected to a Coordinator and [signed in](control_protocol.md#signing-in).
 - Both Components are either connected to the same Coordinator (example one), or their Coordinators are connected to each other (example two).
 
 The following flow chart shows the decision scheme and message modification in the Coordinator `Co1` of Node `N1`.
@@ -306,7 +306,7 @@ Note that the DEALER socket responds with the local Directory and Coordinator ad
 
 ##### Coordinator updates
 
-Each Coordinator SHALL keep an up-to-date global {ref}`control_protocol.md#directory` with the Full names of all Components in the Network.
+Each Coordinator SHALL keep an up-to-date global [Directory](control_protocol.md#directory) with the Full names of all Components in the Network.
 For this, whenever a Component signs in to or out from its Coordinator, the Coordinator SHALL notify all the other Coordinators regarding this event.
 The other Coordinators SHALL update their global Directory according to this message (add or remove an entry).
 
@@ -316,7 +316,7 @@ TBD: These updates have to be determined.
 
 On request, Coordinators SHALL send the Names of their local or global Directory, depending on the request type.
 
-For the format of the Messages, see {ref}`control_protocol.md#message-layer`.
+For the format of the Messages, see [Message layer](control_protocol.md#message-layer).
 
 ## Message layer
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,10 @@ name: leco-protocol
 channels:
   - conda-forge
 dependencies:
-  - myst-parser=0.18.1
+  - myst-parser>=2.0.0
   - python=3.11
   - pip
-  - sphinx=5.3.0
-  - sphinxcontrib-mermaid=0.8.1
-  - sphinx_rtd_theme=1.1.1
+  - sphinx>=6.0
+  - sphinxcontrib-mermaid>=0.9.2
+  - sphinx_rtd_theme>=1.2.0
   - sphinx-data-viewer=0.1.2

--- a/glossary.md
+++ b/glossary.md
@@ -6,69 +6,69 @@ To help distinguish between the plain English meaning of these terms, and our mo
 :::{glossary}
 
 Actor
-    An Actor offers a standardized interface to the LECO network to communicate with some Device. This happens via a Driver contained in the Actor, see {ref}`components.md#actor`. An Actor implements the mapping/translation between LECO messages and the Driver's interface.
+    An Actor offers a standardized interface to the LECO network to communicate with some Device. This happens via a Driver contained in the Actor, see [Actor](components.md#actor). An Actor implements the mapping/translation between LECO messages and the Driver's interface.
 
 Component
-    A type of entity, a set of which make up the LECO communication Network, see {ref}`components.md#components`.
+    A type of entity, a set of which make up the LECO communication Network, see [Components](components.md#components).
 
 Component name
-    The individual name in a Node, under which a Component can be addressed, see {ref}`control_protocol.md#naming-scheme`.
+    The individual name in a Node, under which a Component can be addressed, see [Naming scheme](control_protocol.md#naming-scheme).
 
 Coordinator
-    A Component primarily concerned with routing/coordinating the message flow between other Components, see {ref}`components.md#coordinator`.
+    A Component primarily concerned with routing/coordinating the message flow between other Components, see [Coordinator](components.md#coordinator).
     There are Control Coordinators, Data Coordinators, and Logging Coordinators.
 
 Device
     Some piece of hardware controlled by a Driver.
 
 Director
-    A Component which takes part in orchestrating a (i.e. LECO-controlled) measurement setup, see {ref}`components.md#director`.
+    A Component which takes part in orchestrating a (i.e. LECO-controlled) measurement setup, see [Director](components.md#director).
 
 Directory
-    Each Coordinator maintains a local Directory with all the Components connected to it (i.e. other Coordinators and the Components of its own Node), and a global Directory with all Components in the whole Network, see {ref}`control_protocol.md#directory`.
+    Each Coordinator maintains a local Directory with all the Components connected to it (i.e. other Coordinators and the Components of its own Node), and a global Directory with all Components in the whole Network, see [Directory](control_protocol.md#directory).
 
 Driver
-    An object that takes care of communicating with a Device. This object is external to LECO, for example coming from an instrument control library like `pymeasure`, `instrumentkit` or `yaq`. See {ref}`components.md#driver`.
+    An object that takes care of communicating with a Device. This object is external to LECO, for example coming from an instrument control library like `pymeasure`, `instrumentkit` or `yaq`. See [Driver](components.md#driver).
 
 Full name
     The name of a Component unique for the whole setup.
-    It consists of the namespace and component-name, see {ref}`control_protocol.md#naming-scheme`.
+    It consists of the namespace and component-name, see [Naming scheme](control_protocol.md#naming-scheme).
 
 LECO
     The **L**aboratory **E**xperiment **CO**ntrol protocol framework.
 
 Message
-    A LECO Message is one set of data transmitted from one Component to another, see {ref}`messages.md#messages`.
+    A LECO Message is one set of data transmitted from one Component to another, see [Messages](messages.md#messages).
     Messages are broadly divided into three categories or "channels": control, data, and logging messages.
 
 Message Layer
-    The Message Layer is the communication layer that concerns itself with LECO message (de)composition, validation, serialisation, etc., see {ref}`network-structure.md#message-layer`.
+    The Message Layer is the communication layer that concerns itself with LECO message (de)composition, validation, serialisation, etc., see [Message Layer](network-structure.md#message-layer).
     :::{admonition} TODO
-    The serialisation format for the Message Layer is not yet fully specified; currently JSON encoding is used (see {ref}`control_protocol.md#message-layer`).
+    The serialisation format for the Message Layer is not yet fully specified; currently JSON encoding is used (see [Message layer](control_protocol.md#message-layer)).
     :::
 
 Message Transport Mode (LMT/DMT)
-    The Node-local Message Layer can have a local or distributed mode, see {ref}`network-structure.md#message-transport-mode-lmtdmt`.
+    The Node-local Message Layer can have a local or distributed mode, see [Message Transport Mode (LMT/DMT)](network-structure.md#message-transport-mode-lmtdmt).
 
 Namespace
-    The name of a Node in the Network, see {ref}`control_protocol.md#naming-scheme`.
+    The name of a Node in the Network, see [Naming scheme](control_protocol.md#naming-scheme).
 
 Node
     A Node is a local context in which (part of) a LECO deployment runs.
     This may be a single application using one or more threads or processes.
-    A LECO network has one or more Nodes, see {ref}`network-structure.md#node`.
+    A LECO network has one or more Nodes, see [Node](network-structure.md#node).
 
 Network
     The web of Components communicating with each other in a LECO deployment.
 
 Observer
-    A Component that receives data from other Components, e.g. for logging, storage, or plotting, see {ref}`components.md#observer`.
+    A Component that receives data from other Components, e.g. for logging, storage, or plotting, see [Observer](components.md#observer).
 
 Processor
-    A Component on the LECO network which runs some kind of processing operation on one or more inputs and produces one or more outputs. Can be stateful or stateless. See {ref}`components.md#processor`.
+    A Component on the LECO network which runs some kind of processing operation on one or more inputs and produces one or more outputs. Can be stateful or stateless. See [Processor](components.md#processor).
 
 Transport Layer
     The Transport Layer is the communication layer that transports LECO messages between Components.
-    This uses zeromq or simpler localised methods, see Message Transport Mode above. See {ref}`network-structure.md#transport-layer`.
+    This uses zeromq or simpler localised methods, see Message Transport Mode above. See [Transport Layer](network-structure.md#transport-layer).
 
 :::

--- a/goals.md
+++ b/goals.md
@@ -1,6 +1,6 @@
 # Goals
 
-To guide the design of the specification, here we have articulated the high-level goals of this protocol. Relevant Capitalized terms are defined in our {ref}`glossary.md#glossary`.
+To guide the design of the specification, here we have articulated the high-level goals of this protocol. Relevant Capitalized terms are defined in our [Glossary](glossary.md#glossary).
 
 ## Tying diverse solutions together
 

--- a/methods.md
+++ b/methods.md
@@ -23,7 +23,7 @@ Components SHOULD offer ``shut_down``.
 
 ## Coordinator
 
-Control protocol Coordinators are also {ref}`Components <methods.md#component>`.
+Control protocol Coordinators are also [Components](methods.md#component).
 Furthermore, Coordinators MUST offer the following methods.
 
 :::{leco-json-viewer}
@@ -33,7 +33,7 @@ Furthermore, Coordinators MUST offer the following methods.
 
 ## Actor
 
-An Actor is a {ref}`methods.md#component`.
+An Actor is a [Component](methods.md#component).
 Additionally, it MUST offer the following methods.
 
 :::{leco-json-viewer}
@@ -43,7 +43,7 @@ Additionally, it MUST offer the following methods.
 
 ## Polling Actor
 
-An {ref}`methods.md#actor`, which supports regular polling of values, MUST implement these methods.
+An [Actor](methods.md#actor), which supports regular polling of values, MUST implement these methods.
 
 :::{data-viewer}
 :expand:
@@ -52,11 +52,11 @@ An {ref}`methods.md#actor`, which supports regular polling of values, MUST imple
 
 ## Locking Actor
 
-An {ref}`methods.md#actor` which supports locking resources MUST offer the following methods.
+An [Actor](methods.md#actor) which supports locking resources MUST offer the following methods.
 
 :::{data-viewer}
 :expand:
 :file: schemas/locking_actor.json
 :::
 
-Accessing a locked resource (the whole Component or parts of it) or trying to unlock one, locked by another Component, will raise appropriate {ref}`control_protocol.md#errors`.
+Accessing a locked resource (the whole Component or parts of it) or trying to unlock one, locked by another Component, will raise appropriate [Errors](control_protocol.md#errors).

--- a/network-structure.md
+++ b/network-structure.md
@@ -34,7 +34,7 @@ Put differently, Components MAY only communicate to outside their Node via a Con
 
 In this graph, messages would pass from `Component1` to `Coordinator1` to `Coordinator2` to the destination `Component4`.
 
-:::{mermaid}
+```mermaid
 flowchart LR
 
     subgraph Node1
@@ -46,7 +46,7 @@ flowchart LR
         Coordinator2 -- "connects to" --- Component3
         Coordinator2 -- "connects to" --- Component4
     end
-:::
+```
 
 Control Coordinator to Control Coordinator communication always uses DMT.
 

--- a/network-structure.md
+++ b/network-structure.md
@@ -2,7 +2,7 @@
 
 ## Message Layer
 
-The Message Layer is the communication layer that concerns itself with (de)composition, validation, serialisation, etc. of LECO Messages (see {ref}`messages.md#messages`).
+The Message Layer is the communication layer that concerns itself with (de)composition, validation, serialisation, etc. of LECO Messages (see [Messages](messages.md#messages)).
 
 ## Transport Layer
 
@@ -64,7 +64,7 @@ In this documentation, the separation between frames is indicated by `|`.
 An empty frame is indicated with two frame separators `||`, even at the beginning or end of a message.
 For example, the message `||Second frame|Third frame||Fifth frame` consists of 5 frames, with the first and fourth frames being empty frames.
 
-For some useful information see our {ref}`appendix.md#zmq`.
+For some useful information see our [ZMQ](appendix.md#zmq).
 
 ### Local Message Transport (LMT)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
-    "myst-parser==0.18.1",
-    "sphinx==5.3.0",
-    "sphinxcontrib-mermaid==0.8.1",
-    "sphinx-rtd-theme==1.1.1",
+    "myst-parser>=2.0.0",
+    "sphinx>=6.0",
+    "sphinxcontrib-mermaid>=0.9.2",
+    "sphinx-rtd-theme>=1.2.0",
     "sphinx-data-viewer==0.1.2"
 ]
 

--- a/requirements/leco-protocol.yml
+++ b/requirements/leco-protocol.yml
@@ -1,6 +1,6 @@
 dependencies:
 # Development dependencies below
-  - sphinx=4.3.1
-  - sphinx_rtd_theme=1.0.0
-  - myst-parser
-  - sphinxcontrib-mermaid
+  - sphinx>=6.0
+  - sphinx_rtd_theme>=1.2.0
+  - myst-parser>=2.0.0
+  - sphinxcontrib-mermaid>=0.9.2


### PR DESCRIPTION
Closes #51 

Configure myst_fence_as_directive to treat mermaid code fences as the mermaid directive, enabling interoperable rendering on GitHub and other platforms that understand standard mermaid code fences.

- Add myst_fence_as_directive and attrs_block extension to conf.py
- Convert all mermaid colon-fence blocks to code-fence blocks
- Update dependency versions for myst-parser, sphinx, etc.

Ref: executablebooks/MyST-Parser#742, pymeasure/leco-protocol#51